### PR TITLE
fix: 範囲内の写真だけ出てくるように

### DIFF
--- a/electron/module/logInfo/logInfoCointroller.ts
+++ b/electron/module/logInfo/logInfoCointroller.ts
@@ -67,6 +67,15 @@ export const getRecentVRChatWorldJoinLogByVRChatPhotoName = async (
       joinDateTime: Date;
       createdAt: Date;
       updatedAt: Date;
+      nextJoinLog: {
+        id: string;
+        worldId: string;
+        worldName: string;
+        worldInstanceId: string;
+        joinDateTime: Date;
+        createdAt: Date;
+        updatedAt: Date;
+      } | null;
     },
     'RECENT_JOIN_LOG_NOT_FOUND'
   >

--- a/src/page/Photo.tsx
+++ b/src/page/Photo.tsx
@@ -79,6 +79,9 @@ function PhotoSelector() {
             <VRChatWorldJoinDataView
               vrcWorldId={recentJoinWorldData.worldId}
               joinDateTime={recentJoinWorldData.joinDateTime}
+              nextJoinDateTime={
+                recentJoinWorldData.nextJoinLog?.joinDateTime || null
+              }
             />
           )}
         </div>

--- a/src/page/__Photo/VRChatJoinDataView.tsx
+++ b/src/page/__Photo/VRChatJoinDataView.tsx
@@ -61,14 +61,18 @@ export const VRChatWorldJoinDataView = ({
   vrcWorldId,
   joinDateTime,
   nextJoinDateTime,
-}: { vrcWorldId: string; joinDateTime: Date; nextJoinDateTime?: Date }) => {
+}: {
+  vrcWorldId: string;
+  joinDateTime: Date;
+  nextJoinDateTime: Date | null;
+}): React.ReactElement => {
   const { data } =
     trpcReact.vrchatApi.getVrcWorldInfoByWorldId.useQuery(vrcWorldId);
 
   const { data: vrchatPhotoPathListData } =
     trpcReact.vrchatPhoto.getVrchatPhotoPathModelList.useQuery({
       gtPhotoTakenAt: joinDateTime,
-      ltPhotoTakenAt: nextJoinDateTime,
+      ...(nextJoinDateTime && { ltPhotoTakenAt: nextJoinDateTime }),
       orderByPhotoTakenAt: 'desc',
     });
 
@@ -82,7 +86,13 @@ export const VRChatWorldJoinDataView = ({
                 <div className="relative rounded-md bg-card p-4 flex flex-col overflow-hidden">
                   <div className="max-h-full">
                     <div className="text-sm text-muted-foreground">
-                      Join Date
+                      <span>Join Date</span>
+                      <span>{joinDateTime.toISOString()} ~ </span>
+                      <span>
+                        {nextJoinDateTime
+                          ? nextJoinDateTime.toISOString()
+                          : 'Now'}
+                      </span>
                     </div>
                     <div className="text-xl">
                       {datefns.format(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging system to provide detailed information about the next join log for VRChat worlds.
	- Added functionality to display the next join date and time in the PhotoSelector component.

- **Bug Fixes**
	- Improved handling of the `nextJoinDateTime` prop to ensure clarity and prevent issues when it is null.

- **User Interface Improvements**
	- Enhanced rendering of join date range, defaulting to 'Now' if no next join date is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->