### PR TITLE
feat: 写真を撮っていない時でもJoin記録を表示するように

### DIFF
--- a/electron/electronUtil.ts
+++ b/electron/electronUtil.ts
@@ -79,9 +79,9 @@ function createWindow(): BrowserWindow {
   });
 
   // 開発環境の場合、DevToolsを開く
-  if (isDev) {
-    mainWindow.webContents.openDevTools();
-  }
+  // if (isDev) {
+  //   mainWindow.webContents.openDevTools();
+  // }
 
   const port = process.env.PORT || 3000;
   const url = isDev
@@ -94,9 +94,6 @@ function createWindow(): BrowserWindow {
   } else {
     mainWindow.loadFile(url);
   }
-
-  // デバッグのために常にDevToolsを開く
-  mainWindow.webContents.openDevTools();
 
   // http or httpsのリンクをクリックしたときにデフォルトブラウザで開く
   const handleUrlOpen = (e: Event, url: string) => {

--- a/electron/lib/sequelize.ts
+++ b/electron/lib/sequelize.ts
@@ -100,7 +100,7 @@ const executeSyncRDB = async (options: { force: boolean }) => {
   }
 
   migrationProgeress = true;
-  const appVersion = await settingService.getAppVersion();
+  const appVersion = settingService.getAppVersion();
   try {
     // migration 実行
     const result = await getRDBClient().__client.sync({

--- a/electron/module/backgroundSettings/controller/backgroundSettingsController.ts
+++ b/electron/module/backgroundSettings/controller/backgroundSettingsController.ts
@@ -28,10 +28,30 @@ const getIsAppAutoStartEnabled = async (): Promise<boolean> => {
 };
 
 const setIsAppAutoStartEnabled = async (isEnabled: boolean) => {
-  console.log('isEnabled', isEnabled);
+  console.log('setIsAppAutoStartEnabled: before', app.getLoginItemSettings());
+
+  // macOSの場合、openAsHiddenをtrueに設定することで、バックグラウンドで起動するように
   app.setLoginItemSettings({
     openAtLogin: isEnabled,
+    openAsHidden: true,
   });
+
+  // 設定が反映されるまで少し待つ
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  // 設定が反映されたか確認
+  const newSettings = app.getLoginItemSettings();
+  console.log('setIsAppAutoStartEnabled: after', newSettings);
+
+  if (newSettings.openAtLogin !== isEnabled) {
+    console.error('Failed to update login item settings', {
+      expected: isEnabled,
+      actual: newSettings,
+    });
+    throw new Error('Failed to update login item settings');
+  }
+
+  return true;
 };
 
 export const backgroundSettingsRouter = (

--- a/electron/module/settings/service.ts
+++ b/electron/module/settings/service.ts
@@ -2,7 +2,7 @@ import { app } from 'electron';
 import { type UpdateCheckResult, autoUpdater } from 'electron-updater';
 import * as log from '../../lib/logger';
 
-export const getAppVersion = async (): Promise<string> => {
+export const getAppVersion = (): string => {
   // 本番では app.getVersion() を使用してバージョンを取得
   const appVersionDev = process.env.npm_package_version;
   if (appVersionDev !== undefined) {

--- a/electron/trpc.ts
+++ b/electron/trpc.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'node:events';
 import { initTRPC } from '@trpc/server';
 import superjson from 'superjson';
 import * as log from './lib/logger';
+import * as settingService from './module/settings/service';
 
 const eventEmitter = new EventEmitter();
 
@@ -18,7 +19,7 @@ const logError = (err: Error | string, requestInfo?: string) => {
   } else {
     error = new Error('TRPCErrorLogger', { cause: err });
   }
-  const appVersion = process.env.npm_package_version;
+  const appVersion = settingService.getAppVersion();
   log.error({
     message: `version: ${appVersion}, request: ${requestInfo}`,
     stack: error,

--- a/src/v2/components/PhotoGallery/Header.tsx
+++ b/src/v2/components/PhotoGallery/Header.tsx
@@ -1,3 +1,4 @@
+import { trpcReact } from '@/trpc';
 import { RefreshCw, Settings } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useI18n } from '../../i18n/store';
@@ -12,12 +13,17 @@ interface HeaderProps {
 const Header = memo(({ setSearchQuery, onOpenSettings }: HeaderProps) => {
   const { t } = useI18n();
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const { mutate: loadLogInfo } =
+    trpcReact.logInfo.loadLogInfoIndex.useMutation({
+      onSettled: () => {
+        setIsRefreshing(false);
+      },
+    });
+
   const handleRefresh = async () => {
     if (!isRefreshing) {
       setIsRefreshing(true);
-      setTimeout(() => {
-        setIsRefreshing(false);
-      }, 1000);
+      loadLogInfo();
     }
   };
 

--- a/src/v2/components/PhotoGallery/useGroupPhotos.ts
+++ b/src/v2/components/PhotoGallery/useGroupPhotos.ts
@@ -41,7 +41,7 @@ export function groupPhotosBySession(
   const groups: GroupedPhoto[] = [];
   let remainingPhotos = [...sortedPhotos];
 
-  // 各セッションに対して写真をグループ化
+  // 各セッションに対してグループを作成
   for (let i = 0; i < sortedSessions.length; i++) {
     const currentSession = sortedSessions[i];
     const prevSession = sortedSessions[i - 1];
@@ -61,22 +61,21 @@ export function groupPhotosBySession(
       return photoTime >= sessionTime && photoTime < prevSessionTime;
     });
 
-    if (sessionPhotos.length > 0) {
-      groups.push({
-        photos: sessionPhotos,
-        worldInfo: {
-          worldId: currentSession.worldId,
-          worldName: currentSession.worldName,
-          worldInstanceId: currentSession.worldInstanceId,
-        },
-        joinDateTime: currentSession.joinDateTime,
-      });
+    // 写真の有無に関わらずグループを作成
+    groups.push({
+      photos: sessionPhotos,
+      worldInfo: {
+        worldId: currentSession.worldId,
+        worldName: currentSession.worldName,
+        worldInstanceId: currentSession.worldInstanceId,
+      },
+      joinDateTime: currentSession.joinDateTime,
+    });
 
-      // 処理済みの写真を除外
-      remainingPhotos = remainingPhotos.filter(
-        (photo) => !sessionPhotos.includes(photo),
-      );
-    }
+    // 処理済みの写真を除外
+    remainingPhotos = remainingPhotos.filter(
+      (photo) => !sessionPhotos.includes(photo),
+    );
   }
 
   // 最後のセッションに属する写真を処理（残りの写真がある場合のみ）

--- a/src/v2/components/settings/AppInfo.tsx
+++ b/src/v2/components/settings/AppInfo.tsx
@@ -8,6 +8,7 @@ import { Button } from '../ui/button';
 const AppInfo = memo(() => {
   const { t } = useI18n();
   const { mutate: openLog } = trpcReact.openElectronLogOnExplorer.useMutation();
+  const { data: appVersion } = trpcReact.settings.getAppVersion.useQuery();
 
   const handleOpenLog = () => {
     openLog();
@@ -25,7 +26,7 @@ const AppInfo = memo(() => {
             {t('settings.info.version')}
           </span>
           <span className="font-mono text-gray-900 dark:text-white">
-            {packageJson.version}
+            {appVersion}
           </span>
         </div>
         <div className="flex justify-between">

--- a/src/v2/components/settings/SettingsModal.tsx
+++ b/src/v2/components/settings/SettingsModal.tsx
@@ -118,31 +118,33 @@ const SettingsModal = memo(({ onClose }: SettingsModalProps) => {
           </button>
         </div>
 
-        <div className="flex-none border-b border-gray-200 dark:border-gray-700">
-          <nav className="flex px-6" aria-label="Tabs">
-            {tabs.map(({ id, label, icon: Icon }) => (
-              <button
-                type="button"
-                key={id}
-                onClick={() => setActiveTab(id)}
-                className={`relative py-4 px-1 flex items-center text-sm font-medium ${
-                  activeTab === id
-                    ? 'text-indigo-600 dark:text-indigo-400'
-                    : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'
-                } mr-8`}
-              >
-                <Icon className="h-5 w-5 mr-2" />
-                {label}
-                {activeTab === id && (
-                  <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-indigo-600 dark:bg-indigo-400" />
-                )}
-              </button>
-            ))}
-          </nav>
-        </div>
+        <div className="flex-1 flex">
+          <div className="flex-none w-48 border-r border-gray-200 dark:border-gray-700">
+            <nav className="flex flex-col py-2" aria-label="Tabs">
+              {tabs.map(({ id, label, icon: Icon }) => (
+                <button
+                  type="button"
+                  key={id}
+                  onClick={() => setActiveTab(id)}
+                  className={`relative py-2 px-4 flex items-center text-sm font-medium ${
+                    activeTab === id
+                      ? 'text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-900/20'
+                      : 'text-gray-500 hover:text-gray-700 hover:bg-gray-50 dark:text-gray-400 dark:hover:text-gray-300 dark:hover:bg-gray-700/50'
+                  }`}
+                >
+                  <Icon className="h-5 w-5 mr-2 flex-shrink-0" />
+                  <span className="truncate">{label}</span>
+                  {activeTab === id && (
+                    <span className="absolute left-0 top-0 bottom-0 w-0.5 bg-indigo-600 dark:bg-indigo-400" />
+                  )}
+                </button>
+              ))}
+            </nav>
+          </div>
 
-        <div className="flex-1 overflow-y-auto px-6 py-4">
-          <ActiveComponent />
+          <div className="flex-1 overflow-y-auto p-6">
+            <ActiveComponent />
+          </div>
         </div>
       </div>
     </div>

--- a/src/v2/components/settings/SettingsModal.tsx
+++ b/src/v2/components/settings/SettingsModal.tsx
@@ -144,12 +144,6 @@ const SettingsModal = memo(({ onClose }: SettingsModalProps) => {
         <div className="flex-1 overflow-y-auto px-6 py-4">
           <ActiveComponent />
         </div>
-
-        <div className="flex-none px-6 py-4 bg-gray-50 dark:bg-gray-900/50 rounded-b-lg">
-          <p className="text-sm text-gray-500 dark:text-gray-400">
-            © {new Date().getFullYear()} Photo Gallery. All rights reserved.
-          </p>
-        </div>
       </div>
     </div>
   );

--- a/src/v2/components/settings/SystemSettings.tsx
+++ b/src/v2/components/settings/SystemSettings.tsx
@@ -1,170 +1,128 @@
-import { Power, RefreshCw } from 'lucide-react';
-import React, { memo } from 'react';
+import { trpcReact } from '@/trpc';
+import { memo } from 'react';
+import { useToast } from '../../hooks/use-toast';
 import { useI18n } from '../../i18n/store';
+
+interface ToggleProps {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  disabled?: boolean;
+}
+
+const Toggle = ({ checked, onCheckedChange, disabled }: ToggleProps) => (
+  <button
+    type="button"
+    onClick={() => onCheckedChange(!checked)}
+    disabled={disabled}
+    className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2 ${
+      checked ? 'bg-indigo-600' : 'bg-gray-200 dark:bg-gray-700'
+    } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+    role="switch"
+    aria-checked={checked}
+  >
+    <span
+      aria-hidden="true"
+      className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+        checked ? 'translate-x-5' : 'translate-x-0'
+      }`}
+    />
+  </button>
+);
 
 const SystemSettings = memo(() => {
   const { t } = useI18n();
-  const { settings, updateSettings } = {
-    settings: {
-      startupLaunch: true,
-      backgroundUpdate: true,
-      updateInterval: 5,
-      showNotifications: true,
-    },
-    updateSettings: (_newSettings: typeof settings) => {
-      // 実装は空のまま
-    },
-  };
+  const { toast } = useToast();
+  const utils = trpcReact.useContext();
+
+  const { data: startupLaunch, isLoading: isStartupLoading } =
+    trpcReact.backgroundSettings.getIsAppAutoStartEnabled.useQuery();
+  const { mutate: setStartupLaunch, isLoading: isStartupUpdating } =
+    trpcReact.backgroundSettings.setIsAppAutoStartEnabled.useMutation({
+      onMutate: async (newValue) => {
+        await utils.backgroundSettings.getIsAppAutoStartEnabled.cancel();
+        const previousValue =
+          utils.backgroundSettings.getIsAppAutoStartEnabled.getData();
+        utils.backgroundSettings.getIsAppAutoStartEnabled.setData(
+          undefined,
+          newValue,
+        );
+        return { previousValue };
+      },
+      onError: (err, _newValue, context) => {
+        utils.backgroundSettings.getIsAppAutoStartEnabled.setData(
+          undefined,
+          context?.previousValue,
+        );
+        console.error('Failed to update startup launch setting:', err);
+        toast({
+          title: t('settings.system.startupLaunch'),
+          description: t('settings.system.startupError'),
+          variant: 'destructive',
+        });
+      },
+      onSuccess: () => {
+        toast({
+          title: t('settings.system.startupLaunch'),
+          description: t('settings.system.startupSuccess'),
+        });
+      },
+      onSettled: () => {
+        utils.backgroundSettings.getIsAppAutoStartEnabled.invalidate();
+      },
+    });
+
+  const { data: backgroundUpdate } =
+    trpcReact.backgroundSettings.getIsBackgroundFileCreationEnabled.useQuery();
+  const { mutate: setBackgroundUpdate } =
+    trpcReact.backgroundSettings.setIsBackgroundFileCreationEnabled.useMutation(
+      {
+        onSuccess: () => {
+          utils.backgroundSettings.getIsBackgroundFileCreationEnabled.invalidate();
+        },
+      },
+    );
 
   return (
-    <section>
-      <h3 className="flex items-center text-lg font-medium text-gray-900 dark:text-white mb-4">
-        <Power className="h-5 w-5 mr-2 text-indigo-600 dark:text-indigo-400" />
-        {t('settings.system.title')}
-      </h3>
-
-      <div className="space-y-6">
-        <div className="flex items-center justify-between">
-          <div>
-            <h4 className="text-sm font-medium text-gray-900 dark:text-white">
-              {t('settings.system.startupLaunch')}
-            </h4>
-            <p className="text-sm text-gray-500 dark:text-gray-400">
-              {t('settings.system.startupDescription')}
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() =>
-              updateSettings({
-                ...settings,
-                startupLaunch: !settings.startupLaunch,
-              })
-            }
-            className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2 ${
-              settings.startupLaunch
-                ? 'bg-indigo-600'
-                : 'bg-gray-200 dark:bg-gray-700'
-            }`}
-            role="switch"
-            aria-checked={settings.startupLaunch}
-          >
-            <span
-              aria-hidden="true"
-              className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
-                settings.startupLaunch ? 'translate-x-5' : 'translate-x-0'
-              }`}
-            />
-          </button>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <div>
-            <h4 className="text-sm font-medium text-gray-900 dark:text-white">
-              {t('settings.system.backgroundUpdate')}
-            </h4>
-            <p className="text-sm text-gray-500 dark:text-gray-400">
-              {t('settings.system.backgroundDescription')}
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() =>
-              updateSettings({
-                ...settings,
-                backgroundUpdate: !settings.backgroundUpdate,
-              })
-            }
-            className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2 ${
-              settings.backgroundUpdate
-                ? 'bg-indigo-600'
-                : 'bg-gray-200 dark:bg-gray-700'
-            }`}
-            role="switch"
-            aria-checked={settings.backgroundUpdate}
-          >
-            <span
-              aria-hidden="true"
-              className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
-                settings.backgroundUpdate ? 'translate-x-5' : 'translate-x-0'
-              }`}
-            />
-          </button>
-        </div>
-
-        {settings.backgroundUpdate && (
-          <div className="pl-6 border-l-2 border-gray-100 dark:border-gray-700">
-            <div className="flex items-center justify-between">
-              <div>
-                <h4 className="text-sm font-medium text-gray-900 dark:text-white">
-                  {t('settings.system.updateInterval')}
-                </h4>
-                <p className="text-sm text-gray-500 dark:text-gray-400">
-                  {t('settings.system.updateIntervalDescription')}
-                </p>
-              </div>
-              <select
-                value={settings.updateInterval}
-                onChange={(e) =>
-                  updateSettings({
-                    ...settings,
-                    updateInterval: Number(e.target.value),
-                  })
-                }
-                className="block rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-              >
-                <option value={5}>{t('settings.system.interval.5min')}</option>
-                <option value={15}>
-                  {t('settings.system.interval.15min')}
-                </option>
-                <option value={30}>
-                  {t('settings.system.interval.30min')}
-                </option>
-                <option value={60}>
-                  {t('settings.system.interval.1hour')}
-                </option>
-              </select>
-            </div>
-
-            <div className="mt-4 flex items-center justify-between">
-              <div>
-                <h4 className="text-sm font-medium text-gray-900 dark:text-white">
-                  {t('settings.system.notifications')}
-                </h4>
-                <p className="text-sm text-gray-500 dark:text-gray-400">
-                  {t('settings.system.notificationsDescription')}
-                </p>
-              </div>
-              <button
-                type="button"
-                onClick={() =>
-                  updateSettings({
-                    ...settings,
-                    showNotifications: !settings.showNotifications,
-                  })
-                }
-                className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2 ${
-                  settings.showNotifications
-                    ? 'bg-indigo-600'
-                    : 'bg-gray-200 dark:bg-gray-700'
-                }`}
-                role="switch"
-                aria-checked={settings.showNotifications}
-              >
-                <span
-                  aria-hidden="true"
-                  className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
-                    settings.showNotifications
-                      ? 'translate-x-5'
-                      : 'translate-x-0'
-                  }`}
-                />
-              </button>
-            </div>
-          </div>
-        )}
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-lg font-medium text-gray-900 dark:text-white">
+          {t('settings.system.title')}
+        </h3>
       </div>
-    </section>
+
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="font-medium text-gray-900 dark:text-white">
+              {t('settings.system.startupLaunch')}
+            </div>
+            <div className="text-sm text-gray-500 dark:text-gray-400">
+              {t('settings.system.startupDescription')}
+            </div>
+          </div>
+          <Toggle
+            checked={startupLaunch ?? false}
+            onCheckedChange={setStartupLaunch}
+            disabled={isStartupLoading || isStartupUpdating}
+          />
+        </div>
+
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="font-medium text-gray-900 dark:text-white">
+              {t('settings.system.backgroundUpdate')}
+            </div>
+            <div className="text-sm text-gray-500 dark:text-gray-400">
+              {t('settings.system.backgroundDescription')}
+            </div>
+          </div>
+          <Toggle
+            checked={backgroundUpdate ?? false}
+            onCheckedChange={setBackgroundUpdate}
+          />
+        </div>
+      </div>
+    </div>
   );
 });
 

--- a/src/v2/i18n/locales/en.ts
+++ b/src/v2/i18n/locales/en.ts
@@ -57,6 +57,7 @@ const en: Translations = {
       },
     },
     info: {
+      title: 'App Info',
       version: 'Version',
       name: 'Name',
       dependencies: 'Major Dependencies',

--- a/src/v2/i18n/locales/en.ts
+++ b/src/v2/i18n/locales/en.ts
@@ -31,6 +31,8 @@ const en: Translations = {
       startupDescription: 'Automatically start the application when logging in',
       backgroundUpdate: 'Background Update',
       backgroundDescription: 'Check for new photos in the background',
+      startupError: 'Failed to update startup launch setting',
+      startupSuccess: 'Startup launch setting updated',
       updateInterval: 'Update Interval',
       updateIntervalDescription: 'Frequency of checking for new photos',
       notifications: 'Show Notifications',

--- a/src/v2/i18n/locales/ja.ts
+++ b/src/v2/i18n/locales/ja.ts
@@ -29,6 +29,8 @@ const ja: Translations = {
       title: 'システム設定',
       startupLaunch: '起動時に自動実行',
       startupDescription: 'PCログイン時に自動的にアプリを起動します',
+      startupError: '自動起動の設定に失敗しました',
+      startupSuccess: '自動起動の設定を更新しました',
       backgroundUpdate: 'バックグラウンド更新',
       backgroundDescription: 'バックグラウンドで新しい写真を確認します',
       updateInterval: '更新間隔',

--- a/src/v2/i18n/locales/ja.ts
+++ b/src/v2/i18n/locales/ja.ts
@@ -63,6 +63,7 @@ const ja: Translations = {
       },
     },
     info: {
+      title: 'アプリ情報',
       version: 'バージョン',
       name: 'アプリ名',
       dependencies: '主要な依存関係',

--- a/src/v2/i18n/store.ts
+++ b/src/v2/i18n/store.ts
@@ -2,14 +2,14 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import en from './locales/en';
 import ja from './locales/ja';
-import type { Language, Translations } from './types';
+import type { Language, TranslationKey, Translations } from './types';
 
 const translations: Record<Language, Translations> = { en, ja };
 
 interface I18nState {
   language: Language;
   setLanguage: (lang: Language) => void;
-  t: (key: string) => string;
+  t: (key: TranslationKey) => string;
 }
 
 export const useI18n = create<I18nState>()(

--- a/src/v2/i18n/types.ts
+++ b/src/v2/i18n/types.ts
@@ -1,5 +1,18 @@
 export type Language = 'en' | 'ja';
 
+// 翻訳キーのパスを生成するための型
+export type RecursiveKeyOf<TObj> = {
+  [TKey in keyof TObj & (string | number)]: TObj[TKey] extends Record<
+    string,
+    unknown
+  >
+    ? `${TKey}` | `${TKey}.${RecursiveKeyOf<TObj[TKey]>}`
+    : `${TKey}`;
+}[keyof TObj & (string | number)];
+
+// 翻訳キーの型
+export type TranslationKey = RecursiveKeyOf<Translations>;
+
 export interface Translations {
   common: {
     settings: string;
@@ -62,6 +75,7 @@ export interface Translations {
       };
     };
     info: {
+      title: string;
       version: string;
       name: string;
       dependencies: string;

--- a/src/v2/i18n/types.ts
+++ b/src/v2/i18n/types.ts
@@ -42,6 +42,8 @@ export interface Translations {
       title: string;
       startupLaunch: string;
       startupDescription: string;
+      startupError: string;
+      startupSuccess: string;
       backgroundUpdate: string;
       backgroundDescription: string;
       updateInterval: string;


### PR DESCRIPTION
- **devtools を初めから開く設定をオフにする**
- **不要な right 表示を削除**
- **appVersion の取得元を統一する**
- **設定modalのタブを縦に並ばせる i18nの型定義強化**
- **バックグラウンド設定の詳細実装**
- **HeaderのrefleshボタンでlogIndex の再読み込み**
- **写真を撮っていない時でもJoin記録を表示するように**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added dynamic application version retrieval from the server
  - Enhanced system settings with startup launch and background update toggles

- **UI/UX Improvements**
  - Redesigned settings modal with vertical navigation
  - Improved settings page layout and interaction

- **Localization**
  - Added new translation strings for system settings and app information
  - Enhanced type safety for translation keys

- **Performance**
  - Optimized log loading and refresh mechanisms in photo gallery
  - Streamlined application startup settings management

- **Maintenance**
  - Removed DevTools auto-open in development mode
  - Improved error handling for system settings updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->