### PR TITLE
初期化処理が2度呼ばれていた問題を修正 他

### DIFF
--- a/src/v2/components/LocationGroupHeader.tsx
+++ b/src/v2/components/LocationGroupHeader.tsx
@@ -168,7 +168,7 @@ export const LocationGroupHeader = ({
       ref={containerRef}
       className="bg-white dark:bg-gray-800 rounded-lg shadow-sm overflow-hidden"
     >
-      <div className="relative h-48 overflow-hidden group">
+      <div className="relative h-36 overflow-hidden group">
         <div
           className={`absolute inset-0 ${
             !isImageLoaded || !details?.thumbnailImageUrl
@@ -202,7 +202,7 @@ export const LocationGroupHeader = ({
         <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent" />
         <div className="absolute inset-x-0 bottom-0 p-4 text-white">
           <div className="flex items-center justify-between">
-            <h3 className="text-2xl font-bold flex items-center group/title">
+            <h3 className="text-xl font-bold flex items-center group/title">
               <MapPin className="h-5 w-5 mr-2 flex-shrink-0" />
               <button
                 type="button"

--- a/src/v2/components/LocationGroupHeader.tsx
+++ b/src/v2/components/LocationGroupHeader.tsx
@@ -58,7 +58,7 @@ export const LocationGroupHeader = ({
   const [tooltipPosition, setTooltipPosition] = useState({ top: 0, left: 0 });
   const [isHovered, setIsHovered] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
-  const [isImageLoaded, setIsImageLoaded] = useState(false);
+  const [isImageLoaded, _setIsImageLoaded] = useState(false);
   const [shouldLoadDetails, setShouldLoadDetails] = useState(false);
   const playerListRef = useRef<HTMLSpanElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -184,10 +184,10 @@ export const LocationGroupHeader = ({
                   backgroundImage: `url(${details.thumbnailImageUrl})`,
                   backgroundSize: 'cover',
                   backgroundPosition: 'center',
-                  filter: 'blur(8px)',
+                  filter: 'blur(4px)',
                 }}
               />
-              <img
+              {/* <img
                 src={details.imageUrl}
                 alt={details.name}
                 className={`relative w-full h-full object-cover transition-all duration-700 group-hover:scale-105 ${
@@ -195,7 +195,7 @@ export const LocationGroupHeader = ({
                 }`}
                 loading="lazy"
                 onLoad={() => setIsImageLoaded(true)}
-              />
+              /> */}
             </>
           )}
         </div>

--- a/src/v2/components/PhotoGallery/GalleryContent.tsx
+++ b/src/v2/components/PhotoGallery/GalleryContent.tsx
@@ -155,11 +155,13 @@ const GalleryContent = memo(
                 photoCount={group.photos.length}
                 joinDateTime={group.joinDateTime}
               />
-              {group.photos.length > 0 && (
+              {group.photos.length > 0 ? (
                 <PhotoGrid
                   photos={group.photos}
                   onPhotoSelect={setSelectedPhoto}
                 />
+              ) : (
+                <div className="text-gray-500">No Photos</div>
               )}
             </div>
           ))}

--- a/src/v2/components/PhotoGallery/GalleryContent.tsx
+++ b/src/v2/components/PhotoGallery/GalleryContent.tsx
@@ -130,7 +130,7 @@ const GalleryContent = memo(
       <GalleryErrorBoundary>
         <div
           ref={containerRef}
-          className="flex-1 overflow-y-auto p-4 space-y-4"
+          className="flex-1 overflow-y-auto p-4 space-y-10"
         >
           {/* <div className="bg-gray-100 p-4 rounded-lg text-sm">
             <h3 className="font-bold mb-2">デバッグ情報</h3>

--- a/src/v2/components/PhotoGrid.tsx
+++ b/src/v2/components/PhotoGrid.tsx
@@ -17,10 +17,10 @@ const PhotoGrid: React.FC<PhotoGridProps> = React.memo(
     const { visiblePhotos, isLoading } = useVirtualPhotos(photos);
 
     const getColumnCount = useCallback((width: number) => {
-      if (width < 640) return 1;
-      if (width < 1024) return 2;
-      if (width < 1536) return 3;
-      return 4;
+      if (width < 640) return 2;
+      if (width < 1024) return 3;
+      if (width < 1536) return 4;
+      return 5;
     }, []);
 
     const columnCount = useMemo(
@@ -47,9 +47,9 @@ const PhotoGrid: React.FC<PhotoGridProps> = React.memo(
     }
 
     return (
-      <div ref={containerRef} className="px-4">
+      <div ref={containerRef}>
         <div
-          className="grid gap-4"
+          className="grid gap-2"
           style={{
             gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))`,
           }}
@@ -57,7 +57,7 @@ const PhotoGrid: React.FC<PhotoGridProps> = React.memo(
           {photoColumns.map((column, columnIndex) => (
             <div
               key={`column-${columnIndex}-${column[0]?.id ?? columnIndex}`}
-              className="space-y-4"
+              className="space-y-2"
             >
               {column.map((photo) => (
                 <PhotoCard

--- a/src/v2/hooks/useStartUpStage.ts
+++ b/src/v2/hooks/useStartUpStage.ts
@@ -137,7 +137,13 @@ export const useStartupStage = (callbacks?: ProcessStageCallbacks) => {
     });
 
   const executeLogOperations = useCallback(() => {
-    console.log('executeLogOperations called', { logFilesDirData });
+    console.log('executeLogOperations called', { logFilesDirData, stages });
+
+    if (stages.logsStored !== 'pending') {
+      console.log('Log operations already started or completed');
+      return;
+    }
+
     if (!logFilesDirData) {
       console.log('logFilesDirData is not available');
       return;
@@ -155,6 +161,10 @@ export const useStartupStage = (callbacks?: ProcessStageCallbacks) => {
     }
 
     try {
+      if (stages.logsStored !== 'pending') {
+        console.log('Log operations was started by another call');
+        return;
+      }
       console.log('Starting store logs mutation');
       storeLogsMutation.mutate();
     } catch (error) {
@@ -163,7 +173,7 @@ export const useStartupStage = (callbacks?: ProcessStageCallbacks) => {
         error instanceof Error ? error.message : 'ログの保存に失敗しました';
       updateStage('logsStored', 'error', errorMessage);
     }
-  }, [logFilesDirData]);
+  }, [logFilesDirData, stages, storeLogsMutation, updateStage]);
 
   const retryProcess = useCallback(() => {
     setStages(initialStages);


### PR DESCRIPTION
- **グループ間の余白を広めにとる**
- **余白調整**
- **初期化処理が2度呼ばれていた問題を修正**
- **appendLoglinesToFile の効率化**
- **headerでthumbnailImageUrlのみ表示する**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved log file handling to prevent duplicate entries and handle various file operation scenarios
  - Enhanced error handling for log file operations

- **Style**
  - Adjusted visual layout in `LocationGroupHeader` component
    - Reduced image container height and blur effect
    - Decreased header font size

- **Refactor**
  - Updated photo grid column count and spacing logic
  - Improved startup stage log operations with better control flow and logging

- **New Features**
  - Added "No Photos" placeholder when a photo group is empty

<!-- end of auto-generated comment: release notes by coderabbit.ai -->