### PR TITLE
Add participants information to photo details

### DIFF
--- a/src/v2/components/PhotoCard.tsx
+++ b/src/v2/components/PhotoCard.tsx
@@ -90,6 +90,9 @@ const PhotoCard: React.FC<PhotoCardProps> = memo(
                 <h3 className="text-white font-medium truncate text-xs">
                   {photo.fileName}
                 </h3>
+                <p className="text-white font-medium truncate text-xs">
+                  {photo.participants.join(', ')}
+                </p>
               </div>
             </div>
           </ContextMenuTrigger>

--- a/src/v2/components/PhotoGallery/usePhotoGallery.ts
+++ b/src/v2/components/PhotoGallery/usePhotoGallery.ts
@@ -44,6 +44,7 @@ export function usePhotoGallery(searchQuery: string): {
       location: {
         joinedAt: photo.photoTakenAt,
       },
+      participants: photo.participants || [], // New field to store information about who was present in the photo
     }));
   }, [photoList]);
 

--- a/src/v2/components/PhotoModal.tsx
+++ b/src/v2/components/PhotoModal.tsx
@@ -165,7 +165,16 @@ const PhotoModal: React.FC<PhotoModalProps> = ({ photo, onClose }) => {
                   <Users className="h-4 w-4 mr-2 flex-shrink-0 mt-0.5" />
                   <div>
                     <div className="mb-1">一緒に訪れた人</div>
-                    <div className="flex flex-wrap gap-1" />
+                    <div className="flex flex-wrap gap-1">
+                      {photo.participants.map((participant, index) => (
+                        <span
+                          key={index}
+                          className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200"
+                        >
+                          {participant}
+                        </span>
+                      ))}
+                    </div>
                   </div>
                 </div>
               </div>

--- a/src/v2/types/photo.ts
+++ b/src/v2/types/photo.ts
@@ -8,4 +8,5 @@ export interface Photo {
   location: {
     joinedAt: Date;
   };
+  participants: string[]; // New field to store information about who was present in the photo
 }


### PR DESCRIPTION
Fixes #162

Add participants information to photo details

* Add `participants` field to `Photo` interface in `src/v2/types/photo.ts` to store information about who was present in the photo
* Display `participants` in the photo details in `src/v2/components/PhotoModal.tsx`
* Update `PhotoCard` component in `src/v2/components/PhotoCard.tsx` to include `participants` field
* Update `usePhotoGallery` hook in `src/v2/components/PhotoGallery/usePhotoGallery.ts` to include `participants` field

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tktcorporation/vrchat-photo-journey/pull/185?shareId=3c87cdcc-0e63-4dee-bb1c-5ca5da422b1c).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added participant information to photos
	- Display participants' names in photo cards, gallery, and modal views

- **Documentation**
	- Updated photo type definition to include participants field

The changes enhance the photo viewing experience by providing more context about who was present in each photo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->