### PR TITLE
globに win環境でも / 区切りでパスを渡す

### DIFF
--- a/.github/workflows/lint-test-cross.yml
+++ b/.github/workflows/lint-test-cross.yml
@@ -1,0 +1,48 @@
+name: Lint and Test Cross
+
+on:
+  push:
+
+jobs:
+  lint:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+
+      - run: npm i -g @antfu/ni
+      
+      - name: install dependencies
+        run: nci
+
+      - name: lint
+        run: nr lint
+
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+
+      - run: npm i -g @antfu/ni
+      
+      - name: install dependencies
+        run: nci
+
+      - name: test
+        run: nr test

--- a/electron/module/vrchatLog/service.test.ts
+++ b/electron/module/vrchatLog/service.test.ts
@@ -1,6 +1,4 @@
-import * as fs from 'node:fs';
-import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BaseValueObject } from '../vrchatPhoto/valueObjects';
 import { getLogLinesFromLogPhotoDirPath } from './service';
 
@@ -31,9 +29,7 @@ describe('getLogLinesFromLogPhotoDirPath', () => {
     });
 
     expect(glob).toHaveBeenCalledTimes(1);
-    expect(glob).toHaveBeenCalledWith(
-      path.join('/mock/photo/dir', '**/VRChat_*_wrld_*'),
-    );
+    expect(glob).toHaveBeenCalledWith('/mock/photo/dir/**/VRChat_*_wrld_*');
   });
 
   it('正しい形式のファイル名からワールド訪問ログを抽出できる', async () => {

--- a/electron/module/vrchatLog/service.ts
+++ b/electron/module/vrchatLog/service.ts
@@ -366,7 +366,11 @@ export const getLogLinesFromLogPhotoDirPath = async ({
   log.info('getLogLinesFromLogPhotoDirPath');
 
   log.info(`vrChatPhotoDirPath: ${vrChatPhotoDirPath.value}`);
-  const globPath = path.join(vrChatPhotoDirPath.value, '**', 'VRChat_*_wrld_*');
+  const globPath = path.posix.join(
+    vrChatPhotoDirPath.value,
+    '**',
+    'VRChat_*_wrld_*',
+  );
   log.info(`globPath: ${globPath}`);
   // 正規表現にマッチするファイルを再起的に取得していく
   const logPhotoFilePathList = await glob(globPath);


### PR DESCRIPTION
- **ci: lnt,test を win環境でも動かす**
- **globに win環境でも `/` 区切りでパスを渡す**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI/CD**
	- Added a new GitHub Actions workflow for automated linting and cross-platform testing
	- Workflow runs tests on Ubuntu and Windows environments

- **Code Improvements**
	- Updated path handling in VRChat log service to improve cross-platform compatibility
	- Simplified test case path construction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->