### PR TITLE
fix: 写真から取得じたログと通常ログの重複を想定

### DIFF
--- a/electron/module/vrchatWorldJoinLog/service.test.ts
+++ b/electron/module/vrchatWorldJoinLog/service.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { mergeVRChatWorldJoinLogs } from './service';
+
+describe('mergeVRChatWorldJoinLogs', () => {
+  const baseDate = new Date('2024-01-01T00:00:00.000Z');
+
+  it('通常のログと写真ログを正しくマージする', () => {
+    const normalLogs = [
+      {
+        id: 'normal1',
+        worldId: 'wrld_1',
+        worldName: 'World 1',
+        worldInstanceId: 'instance1',
+        joinDateTime: baseDate,
+        createdAt: baseDate,
+        updatedAt: null,
+      },
+    ];
+
+    const photoLogs = [
+      {
+        id: 'photo1',
+        worldId: 'wrld_2',
+        joinDate: new Date(baseDate.getTime() + 1000),
+        createdAt: baseDate,
+        updatedAt: null,
+      },
+    ];
+
+    const result = mergeVRChatWorldJoinLogs({ normalLogs, photoLogs });
+
+    expect(result).toHaveLength(2);
+    expect(result).toContainEqual(normalLogs[0]);
+    expect(result).toContainEqual({
+      id: 'photo1',
+      worldId: 'wrld_2',
+      worldName: 'wrld_2',
+      worldInstanceId: '',
+      joinDateTime: photoLogs[0].joinDate,
+      createdAt: baseDate,
+      updatedAt: null,
+    });
+  });
+
+  it('重複するログの場合は通常のログを優先する', () => {
+    const normalLogs = [
+      {
+        id: 'normal1',
+        worldId: 'wrld_1',
+        worldName: 'World 1',
+        worldInstanceId: 'instance1',
+        joinDateTime: baseDate,
+        createdAt: baseDate,
+        updatedAt: null,
+      },
+    ];
+
+    const photoLogs = [
+      {
+        id: 'photo1',
+        worldId: 'wrld_1',
+        joinDate: baseDate,
+        createdAt: baseDate,
+        updatedAt: null,
+      },
+    ];
+
+    const result = mergeVRChatWorldJoinLogs({ normalLogs, photoLogs });
+
+    expect(result).toHaveLength(1);
+    expect(result).toContainEqual(normalLogs[0]);
+  });
+
+  it('空の配列の場合は正しく処理する', () => {
+    const result = mergeVRChatWorldJoinLogs({ normalLogs: [], photoLogs: [] });
+    expect(result).toHaveLength(0);
+  });
+});

--- a/electron/module/vrchatWorldJoinLog/service.ts
+++ b/electron/module/vrchatWorldJoinLog/service.ts
@@ -62,3 +62,55 @@ export const getLatestJoinDate = async (): Promise<string | null> => {
 export const findLatestWorldJoinLog = async () => {
   return model.findLatestWorldJoinLog();
 };
+
+export type VRChatWorldJoinLogWithSource = {
+  id: string;
+  worldId: string;
+  worldName: string;
+  worldInstanceId: string;
+  joinDateTime: Date;
+  createdAt: Date;
+  updatedAt: Date | null;
+};
+
+/**
+ * 通常のログと写真から取得したログをマージします
+ * 重複がある場合は通常のログを優先します
+ */
+export const mergeVRChatWorldJoinLogs = ({
+  normalLogs,
+  photoLogs,
+}: {
+  normalLogs: VRChatWorldJoinLogWithSource[];
+  photoLogs: {
+    id: string;
+    worldId: string;
+    joinDate: Date;
+    createdAt: Date;
+    updatedAt: Date | null;
+  }[];
+}): VRChatWorldJoinLogWithSource[] => {
+  // 写真から取得したログを通常のログの形式に変換
+  const convertedPhotoLogs: VRChatWorldJoinLogWithSource[] = photoLogs.map(
+    (log) => ({
+      id: log.id,
+      worldId: log.worldId,
+      worldName: log.worldId, // 写真からは取得できない
+      worldInstanceId: '', // 写真からは取得できない
+      joinDateTime: log.joinDate,
+      createdAt: log.createdAt,
+      updatedAt: log.updatedAt,
+    }),
+  );
+
+  // 写真から取得したログから、通常のログと重複するものを除外
+  const uniquePhotoLogs = convertedPhotoLogs.filter((photoLog) => {
+    return !normalLogs.some(
+      (normalLog) =>
+        normalLog.worldId === photoLog.worldId &&
+        normalLog.joinDateTime.getTime() === photoLog.joinDateTime.getTime(),
+    );
+  });
+
+  return [...normalLogs, ...uniquePhotoLogs];
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced VRChat world join log merging functionality
	- Improved log processing to handle normal and photo logs more efficiently

- **Tests**
	- Added comprehensive test suite for log merging function
	- Verified handling of log duplicates and edge cases

- **Refactor**
	- Streamlined log combination process in the controller
	- Introduced a dedicated function for merging different log sources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->