### PR TITLE
feat: 詳細から戻ったときに直前に開いていた写真がわかるエフェクト

### DIFF
--- a/src/v2/components/PhotoGallery/GalleryContent.tsx
+++ b/src/v2/components/PhotoGallery/GalleryContent.tsx
@@ -28,6 +28,8 @@ const GalleryContent = memo(
       isLoading: isLoadingGrouping,
       selectedPhoto,
       setSelectedPhoto,
+      lastSelectedPhoto,
+      setLastSelectedPhoto,
     } = usePhotoGallery(searchQuery);
     const containerRef = useRef<HTMLDivElement>(null);
     const groupSizesRef = useRef<Map<string, number>>(new Map());
@@ -99,6 +101,8 @@ const GalleryContent = memo(
                         worldId={group.worldInfo?.worldId ?? null}
                         photos={group.photos}
                         onPhotoSelect={setSelectedPhoto}
+                        setLastSelectedPhoto={setLastSelectedPhoto}
+                        lastSelectedPhotoId={lastSelectedPhoto?.id}
                       />
                     ) : (
                       <div className="text-center py-8 text-gray-500 bg-gray-50 dark:bg-gray-800 rounded-lg">

--- a/src/v2/components/PhotoGallery/usePhotoGallery.ts
+++ b/src/v2/components/PhotoGallery/usePhotoGallery.ts
@@ -1,6 +1,6 @@
 import { trpcReact } from '@/trpc';
 import pathe from 'pathe';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { Photo } from '../../types/photo';
 import { VRChatPhotoFileNameWithExtSchema } from './../../../valueObjects';
 import {
@@ -14,9 +14,14 @@ export function usePhotoGallery(searchQuery: string): {
   isLoading: boolean;
   selectedPhoto: Photo | null;
   setSelectedPhoto: (photo: Photo | null) => void;
+  lastSelectedPhoto: Photo | null;
+  setLastSelectedPhoto: (photo: Photo | null) => void;
   debug: DebugInfo;
 } {
   const [selectedPhoto, setSelectedPhoto] = useState<Photo | null>(null);
+  const [lastSelectedPhoto, setLastSelectedPhoto] = useState<Photo | null>(
+    null,
+  );
 
   const { data: photoList, isLoading: isLoadingPhotos } =
     trpcReact.vrchatPhoto.getVrchatPhotoPathModelList.useQuery(
@@ -95,6 +100,8 @@ export function usePhotoGallery(searchQuery: string): {
     isLoading,
     selectedPhoto,
     setSelectedPhoto,
+    lastSelectedPhoto,
+    setLastSelectedPhoto,
     debug,
   };
 }

--- a/src/v2/components/PhotoGrid.tsx
+++ b/src/v2/components/PhotoGrid.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { Photo } from '../types/photo';
 import PhotoCard from './PhotoCard';
@@ -6,6 +7,8 @@ interface PhotoGridProps {
   photos: Photo[];
   worldId: string | null;
   onPhotoSelect: (photo: Photo) => void;
+  setLastSelectedPhoto: (photo: Photo | null) => void;
+  lastSelectedPhotoId?: string | number;
 }
 
 const TARGET_ROW_HEIGHT = 200; // 目標の行の高さ
@@ -22,6 +25,8 @@ export default function PhotoGrid({
   photos,
   worldId,
   onPhotoSelect,
+  setLastSelectedPhoto,
+  lastSelectedPhotoId,
 }: PhotoGridProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState(0);
@@ -137,11 +142,17 @@ export default function PhotoGrid({
                       width: photo.displayWidth,
                       flexShrink: 0,
                     }}
+                    className={clsx(
+                      'relative aspect-video transition-all duration-300',
+                      photo.id === lastSelectedPhotoId &&
+                        'ring-2 ring-blue-400 ring-offset-2 shadow-[0_0_30px_2px_rgba(59,130,246,0.3)] dark:shadow-[0_0_30px_2px_rgba(147,197,253,0.3)]',
+                    )}
                   >
                     <PhotoCard
                       photo={photo}
                       worldId={worldId}
                       onSelect={onPhotoSelect}
+                      setLastSelectedPhoto={setLastSelectedPhoto}
                       priority={index === 0}
                     />
                   </div>

--- a/src/v2/components/VirtualGridRow.tsx
+++ b/src/v2/components/VirtualGridRow.tsx
@@ -7,8 +7,8 @@ interface VirtualGridRowProps {
   worldId: string | null;
   start: number;
   height: number;
-  isPriority?: boolean;
   onPhotoSelect: (photo: Photo) => void;
+  setLastSelectedPhoto: (photo: Photo | null) => void;
 }
 
 const VirtualGridRow: React.FC<VirtualGridRowProps> = React.memo(
@@ -17,8 +17,8 @@ const VirtualGridRow: React.FC<VirtualGridRowProps> = React.memo(
     worldId,
     start,
     height,
-    isPriority = false,
     onPhotoSelect,
+    setLastSelectedPhoto,
   }) => {
     if (!photos || photos.length === 0) return null;
 
@@ -65,8 +65,8 @@ const VirtualGridRow: React.FC<VirtualGridRowProps> = React.memo(
             <PhotoCard
               photo={photo}
               worldId={worldId}
-              priority={isPriority}
               onSelect={onPhotoSelect}
+              setLastSelectedPhoto={setLastSelectedPhoto}
             />
           </div>
         ))}


### PR DESCRIPTION
- Introduce `lastSelectedPhoto` state in `usePhotoGallery` hook
- Add `setLastSelectedPhoto` prop to PhotoCard and PhotoGrid components
- Implement visual highlighting for the last selected photo
- Add context menu action to track last selected photo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced photo selection across the gallery: now, the last photo you select is consistently remembered regardless of whether you interact via a direct click or context menu.
  - Improved visual cues in the gallery highlight the selected photo for a smoother and more intuitive browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->