### PR TITLE
Add refresh button to gallery header

### DIFF
--- a/src/v2/components/PhotoGallery/Header.tsx
+++ b/src/v2/components/PhotoGallery/Header.tsx
@@ -159,6 +159,17 @@ const Header = memo(
             <Button variant="ghost" size="icon" onClick={onOpenSettings}>
               <Settings className="w-5 h-5" />
             </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={_handleRefresh}
+              disabled={isRefreshing}
+              title={t('common.refresh')}
+            >
+              <RefreshCw
+                className={`w-5 h-5 ${isRefreshing ? 'animate-spin' : ''}`}
+              />
+            </Button>
             {/* 必要であれば他の要素 */}
           </div>
         )}


### PR DESCRIPTION
## Summary
- bring back refresh button in the photo gallery header

## Testing
- `yarn lint`
- `yarn test` *(fails: fetch errors for VRChat API)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a refresh button to the Photo Gallery header, allowing users to manually refresh content. The button displays a spinning animation during refresh and includes a tooltip for accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->