### PR TITLE
Send unhandled errors to Sentry

### DIFF
--- a/src/v2/components/ErrorBoundary.tsx
+++ b/src/v2/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { trpcReact } from '@/trpc';
+import { captureException } from '@sentry/electron/renderer';
 import type React from 'react';
 import { ErrorBoundary as ReactErrorBoundary } from 'react-error-boundary';
 
@@ -44,6 +45,7 @@ const ErrorFallback: React.FC<{
 export const ErrorBoundary: React.FC<Props> = ({ children }) => {
   const onError = (error: Error, info: React.ErrorInfo) => {
     console.error('エラーバウンダリーでエラーをキャッチしました:', error, info);
+    captureException(error);
   };
 
   return (


### PR DESCRIPTION
## Summary
- report uncaught exceptions in the main process to Sentry
- forward renderer crashes and React error boundary errors to Sentry

## Testing
- `yarn test` *(fails: getaddrinfo ENOTFOUND api.vrchat.cloud)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Integrated Sentry error reporting throughout the application, including the main process, renderer process, and error boundaries, to enhance error monitoring and diagnostics for uncaught exceptions and unhandled promise rejections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->