### PR TITLE
Add screenshot comment automation

### DIFF
--- a/.github/workflows/wip-screenshot.yml
+++ b/.github/workflows/wip-screenshot.yml
@@ -42,39 +42,29 @@ jobs:
       - name: Comment PR with screenshot
         uses: actions/github-script@v7
         env:
-          screenshotUrl: ${{ steps.upload-screenshot.outputs.artifact-url }}
-        with:
-          script: |
-            const screenshotPath = process.env.screenshotUrl;
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '![screenshot](' + screenshotPath + ')'
-            });
-
-      - name: debug
-        run: |
-          pwd
-          ls
-          ls playwright
-          ls playwright/previews
-
-      - name: Comment PR with screenshot 2
-        uses: actions/github-script@v7
-        env:
           screenshotPath: './playwright/previews/'
         with:
           script: |
             const path = require('path');
-            const screenshotPath = path.resolve(process.env.screenshotPath);
             const fs = require('fs');
-            const screenshotList = fs.readdirSync(screenshotPath).filter(file => file.endsWith('.png'));
-            const screenshot = screenshotList[0];
-            const base64encoded = fs.readFileSync(`${screenshotPath}/${screenshot}`, 'base64');
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '![screenshot](data:image/png;base64,' + base64encoded + ')'
-            });
+            const screenshotDir = path.resolve(process.env.screenshotPath);
+            const screenshots = fs.readdirSync(screenshotDir).filter(f => f.endsWith('.png'));
+            if (screenshots.length === 0) {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: 'No screenshot generated.'
+              });
+            } else {
+              const bodies = screenshots.map(file => {
+                const base64 = fs.readFileSync(path.join(screenshotDir, file), 'base64');
+                return `![${file}](data:image/png;base64,${base64})`;
+              });
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: bodies.join('\n')
+              });
+            }


### PR DESCRIPTION
## Summary
- adjust screenshot workflow to embed base64 encoded screenshots in PR comments

## Testing
- `yarn lint`
- `yarn test` *(fails: fetch failed)*