### PR TITLE
Fix Sentry renderer bundle

### DIFF
--- a/electron/vite.config.ts
+++ b/electron/vite.config.ts
@@ -27,7 +27,6 @@ export default defineConfig({
         // Sentry 関連のモジュール
         '@sentry/electron',
         '@sentry/electron/main',
-        '@sentry/electron/renderer',
         '@sentry/electron/preload',
         '@sentry/vite-plugin',
         // Electron 関連のモジュール

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,6 @@ export default ({ command }: ConfigEnv): UserConfig => {
           external: [
             '@sentry/electron',
             '@sentry/electron/main',
-            '@sentry/electron/renderer',
             '@sentry/electron/preload',
           ],
         },
@@ -70,7 +69,6 @@ export default ({ command }: ConfigEnv): UserConfig => {
         external: [
           '@sentry/electron',
           '@sentry/electron/main',
-          '@sentry/electron/renderer',
           '@sentry/electron/preload',
         ],
       },


### PR DESCRIPTION
## Summary
- fix rollup config so Sentry renderer is bundled

## Testing
- `yarn lint`
- `yarn test` *(fails: getaddrinfo ENOTFOUND api.vrchat.cloud)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated build configuration to change how certain dependencies are handled during the build process. No impact on visible features or functionality for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->