### PR TITLE
Fix Sentry environment for dev mode

### DIFF
--- a/electron/index.ts
+++ b/electron/index.ts
@@ -30,10 +30,13 @@ export const initializeMainSentry = () => {
   }
 
   log.info('Sentry initializing in main process via electron/index.ts');
+  const isDevelopment = process.env.NODE_ENV !== 'production';
+  const environment = isDevelopment ? 'development' : 'production';
+
   initSentry({
     dsn: process.env.SENTRY_DSN,
-    environment: process.env.NODE_ENV,
-    debug: process.env.NODE_ENV !== 'production',
+    environment,
+    debug: isDevelopment,
     beforeSend: (event) => {
       if (settingStore.getTermsAccepted()) {
         return event;

--- a/src/v2/App.tsx
+++ b/src/v2/App.tsx
@@ -39,9 +39,10 @@ function AppContent() {
     trpcReact.initializeSentry.useMutation({
       onSuccess: () => {
         const isDevelopment = process.env.NODE_ENV !== 'production';
+        const environment = isDevelopment ? 'development' : 'production';
         initSentry({
           dsn: process.env.SENTRY_DSN, // 環境変数からDSNを取得
-          environment: process.env.NODE_ENV,
+          environment,
           debug: isDevelopment,
           tags: {
             source: 'electron-renderer',


### PR DESCRIPTION
## Summary
- ensure Sentry events from development are labeled with environment `development`

## Testing
- `yarn lint`
- `yarn test` *(fails: getaddrinfo ENOTFOUND api.vrchat.cloud)*