### PR TITLE
Fix Sentry IPC preload

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,3 +1,8 @@
+import '@sentry/electron/preload';
+/**
+ * Electron の preload スクリプト。
+ * Sentry の IPC 連携を有効化するため、`@sentry/electron/preload` を読み込む。
+ */
 import { contextBridge, ipcRenderer } from 'electron';
 
 import type { Operation } from '@trpc/client';


### PR DESCRIPTION
## Summary
- enable Sentry IPC communication in the preload script so renderer events are sent via IPC

## Testing
- `yarn lint`
- `yarn test` *(fails: fetch failed to api.vrchat.cloud)*