### PR TITLE
chore: electron-builderの設定を更新し、node_modulesをファイルリストに追加。vite.config.tsでSentryのpreloadモジュールをexternalから除外。

### DIFF
--- a/electron-builder.cjs
+++ b/electron-builder.cjs
@@ -4,7 +4,8 @@
  */
 const config = {
   asar: true,
-  files: ['main', 'src/out'],
+  // node_modules を削除する検討
+  files: ['main', 'src/out', 'node_modules/**/*'],
   directories: {
     buildResources: 'assets',
   },

--- a/electron/vite.config.ts
+++ b/electron/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
         // Sentry 関連のモジュール
         '@sentry/electron',
         '@sentry/electron/main',
-        '@sentry/electron/preload',
+        // '@sentry/electron/preload' は preload バンドルに内包させるため external から除外
         '@sentry/vite-plugin',
         // Electron 関連のモジュール
         'electron',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build configuration to include all files from the node_modules directory.
  - Adjusted build process to bundle the '@sentry/electron/preload' module within the preload output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->