### PR TITLE
Fix Sentry preload bundling

### DIFF
--- a/electron/vite.config.ts
+++ b/electron/vite.config.ts
@@ -27,7 +27,6 @@ export default defineConfig({
         // Sentry 関連のモジュール
         '@sentry/electron',
         '@sentry/electron/main',
-        '@sentry/electron/preload',
         '@sentry/vite-plugin',
         // Electron 関連のモジュール
         'electron',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,11 +23,7 @@ export default ({ command }: ConfigEnv): UserConfig => {
         outDir: join(srcRoot, '/out'),
         emptyOutDir: true,
         rollupOptions: {
-          external: [
-            '@sentry/electron',
-            '@sentry/electron/main',
-            '@sentry/electron/preload',
-          ],
+          external: ['@sentry/electron', '@sentry/electron/main'],
         },
         sourcemap: true,
       },
@@ -66,11 +62,7 @@ export default ({ command }: ConfigEnv): UserConfig => {
       outDir: join(srcRoot, '/out'),
       emptyOutDir: true,
       rollupOptions: {
-        external: [
-          '@sentry/electron',
-          '@sentry/electron/main',
-          '@sentry/electron/preload',
-        ],
+        external: ['@sentry/electron', '@sentry/electron/main'],
       },
       sourcemap: true,
     },


### PR DESCRIPTION
## Summary
- stop excluding `@sentry/electron/preload` from the bundles

## Testing
- `yarn lint`
- `yarn test` *(fails: ENOTFOUND api.vrchat.cloud)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated build configuration to change how certain dependencies are handled during the build process. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->