### PR TITLE
Fix missing Sentry DSN in electron main build

### DIFF
--- a/electron/vite.config.ts
+++ b/electron/vite.config.ts
@@ -11,6 +11,10 @@ const nodeBuiltins = [
 export default defineConfig({
   mode: process.env.NODE_ENV || 'development',
   root: __dirname,
+  define: {
+    'process.env.SENTRY_DSN': JSON.stringify(process.env.SENTRY_DSN),
+    'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+  },
   build: {
     outDir: join(__dirname, '../main'),
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
- embed `SENTRY_DSN` in the electron main bundle

## Testing
- `yarn lint`
- `yarn test` *(fails: getaddrinfo ENOTFOUND api.vrchat.cloud)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build configuration to ensure certain environment variables are available in the bundled application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->