### PR TITLE
Enable macOS build for both architectures

### DIFF
--- a/.github/workflows/upload-build-files.yml
+++ b/.github/workflows/upload-build-files.yml
@@ -127,8 +127,8 @@ jobs:
             nlx electron-builder --config=electron-builder.cjs --${{ matrix.os == 'windows-latest' && 'win' || matrix.os == 'ubuntu-22.04' && 'linux' || 'mac' }} --publish never
             tag_string=$(echo "${GITHUB_REF##*/}" | sed 's/v//')
             echo "tag_string: $tag_string"
-            for file in ./dist/*; do
-              result=$(gh release upload "$tag_string" "$file" || echo "failed")
+            find ./dist -maxdepth 1 -type f -print0 | while IFS= read -r -d '' file; do
+              result=$(gh release upload "$tag_string" "$file" --clobber || echo "failed")
               echo "result: $file $result"
             done
           fi

--- a/electron-builder.cjs
+++ b/electron-builder.cjs
@@ -32,7 +32,12 @@ const config = {
     icon: 'assets/icons',
   },
   mac: {
-    target: 'dmg',
+    target: [
+      {
+        target: 'dmg',
+        arch: ['x64', 'arm64'],
+      },
+    ],
     identity: null,
     icon: 'assets/icon.icns',
   },

--- a/src/assets/licenses.json
+++ b/src/assets/licenses.json
@@ -175,11 +175,11 @@
     "path": "node_modules/@electron/get",
     "licenseFile": "node_modules/@electron/get/LICENSE"
   },
-  "@esbuild/linux-arm64@0.21.5": {
+  "@esbuild/linux-x64@0.21.5": {
     "licenses": "MIT",
     "repository": "https://github.com/evanw/esbuild",
-    "path": "node_modules/@esbuild/linux-arm64",
-    "licenseFile": "node_modules/@esbuild/linux-arm64/README.md"
+    "path": "node_modules/@esbuild/linux-x64",
+    "licenseFile": "node_modules/@esbuild/linux-x64/README.md"
   },
   "@fastify/otel@0.8.0": {
     "licenses": "MIT",
@@ -231,21 +231,21 @@
     "path": "node_modules/@heroicons/react",
     "licenseFile": "node_modules/@heroicons/react/LICENSE"
   },
-  "@img/sharp-libvips-linux-arm64@1.0.2": {
+  "@img/sharp-libvips-linux-x64@1.0.2": {
     "licenses": "LGPL-3.0-or-later",
     "repository": "https://github.com/lovell/sharp-libvips",
     "publisher": "Lovell Fuller",
     "email": "npm@lovell.info",
-    "path": "node_modules/sharp/node_modules/@img/sharp-libvips-linux-arm64",
-    "licenseFile": "node_modules/sharp/node_modules/@img/sharp-libvips-linux-arm64/README.md"
+    "path": "node_modules/sharp/node_modules/@img/sharp-libvips-linux-x64",
+    "licenseFile": "node_modules/sharp/node_modules/@img/sharp-libvips-linux-x64/README.md"
   },
-  "@img/sharp-linux-arm64@0.33.3": {
+  "@img/sharp-linux-x64@0.33.3": {
     "licenses": "Apache-2.0",
     "repository": "https://github.com/lovell/sharp",
     "publisher": "Lovell Fuller",
     "email": "npm@lovell.info",
-    "path": "node_modules/sharp/node_modules/@img/sharp-linux-arm64",
-    "licenseFile": "node_modules/sharp/node_modules/@img/sharp-linux-arm64/LICENSE"
+    "path": "node_modules/sharp/node_modules/@img/sharp-linux-x64",
+    "licenseFile": "node_modules/sharp/node_modules/@img/sharp-linux-x64/LICENSE"
   },
   "@isaacs/cliui@8.0.2": {
     "licenses": "ISC",
@@ -1004,12 +1004,12 @@
     "path": "node_modules/@remix-run/router",
     "licenseFile": "node_modules/@remix-run/router/LICENSE.md"
   },
-  "@rollup/rollup-linux-arm64-gnu@4.40.0": {
+  "@rollup/rollup-linux-x64-gnu@4.40.0": {
     "licenses": "MIT",
     "repository": "https://github.com/rollup/rollup",
     "publisher": "Lukas Taegert-Atkinson",
-    "path": "node_modules/@rollup/rollup-linux-arm64-gnu",
-    "licenseFile": "node_modules/@rollup/rollup-linux-arm64-gnu/README.md"
+    "path": "node_modules/@rollup/rollup-linux-x64-gnu",
+    "licenseFile": "node_modules/@rollup/rollup-linux-x64-gnu/README.md"
   },
   "@sentry-internal/browser-utils@9.18.0": {
     "licenses": "MIT",
@@ -1060,17 +1060,17 @@
     "path": "node_modules/@sentry/bundler-plugin-core",
     "licenseFile": "node_modules/@sentry/bundler-plugin-core/LICENSE"
   },
-  "@sentry/cli-linux-arm64@2.42.2": {
+  "@sentry/cli-linux-x64@2.42.2": {
     "licenses": "BSD-3-Clause",
     "repository": "https://github.com/getsentry/sentry-cli",
-    "path": "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-linux-arm64",
-    "licenseFile": "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-linux-arm64/README.md"
+    "path": "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-linux-x64",
+    "licenseFile": "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-linux-x64/README.md"
   },
-  "@sentry/cli-linux-arm64@2.45.0": {
+  "@sentry/cli-linux-x64@2.45.0": {
     "licenses": "BSD-3-Clause",
     "repository": "https://github.com/getsentry/sentry-cli",
-    "path": "node_modules/@sentry/cli-linux-arm64",
-    "licenseFile": "node_modules/@sentry/cli-linux-arm64/README.md"
+    "path": "node_modules/@sentry/cli-linux-x64",
+    "licenseFile": "node_modules/@sentry/cli-linux-x64/README.md"
   },
   "@sentry/cli@2.42.2": {
     "licenses": "BSD-3-Clause",
@@ -1183,11 +1183,11 @@
     "path": "node_modules/@tanstack/virtual-core",
     "licenseFile": "node_modules/@tanstack/virtual-core/LICENSE"
   },
-  "@tktcorporation/hello-napi-linux-arm64-gnu@1.0.4": {
+  "@tktcorporation/hello-napi-linux-x64-gnu@1.0.4": {
     "licenses": "MIT",
     "repository": "https://github.com/tktcorporation/hello-napi-rs",
-    "path": "node_modules/@tktcorporation/hello-napi-linux-arm64-gnu",
-    "licenseFile": "node_modules/@tktcorporation/hello-napi-linux-arm64-gnu/README.md"
+    "path": "node_modules/@tktcorporation/hello-napi-linux-x64-gnu",
+    "licenseFile": "node_modules/@tktcorporation/hello-napi-linux-x64-gnu/README.md"
   },
   "@tktcorporation/hello-napi@1.0.4": {
     "licenses": "MIT",
@@ -2115,11 +2115,11 @@
     "path": "node_modules/electron-log",
     "licenseFile": "node_modules/electron-log/LICENSE"
   },
-  "electron-pan-clip-linux-arm64-gnu@0.0.32": {
+  "electron-pan-clip-linux-x64-gnu@0.0.32": {
     "licenses": "MIT",
     "repository": "https://github.com/tktcorporation/electron-pan-clip",
-    "path": "node_modules/electron-pan-clip-linux-arm64-gnu",
-    "licenseFile": "node_modules/electron-pan-clip-linux-arm64-gnu/README.md"
+    "path": "node_modules/electron-pan-clip-linux-x64-gnu",
+    "licenseFile": "node_modules/electron-pan-clip-linux-x64-gnu/README.md"
   },
   "electron-pan-clip@0.0.32": {
     "licenses": "MIT",


### PR DESCRIPTION
## Summary
- ensure macOS dmg is produced for both x64 and arm64
- upload only build files when attaching release artifacts

## Testing
- `yarn lint`
- `yarn test` *(fails: getaddrinfo ENOTFOUND api.vrchat.cloud)*