### PR TITLE
fix: ResizeObserver loop errors and missing data-index attributes

### DIFF
--- a/src/v2/components/PhotoGallery/GalleryContent.tsx
+++ b/src/v2/components/PhotoGallery/GalleryContent.tsx
@@ -81,14 +81,21 @@ const GalleryContent = memo(
         [filteredGroups],
       ),
       overscan: 1,
-      measureElement: useCallback((element: HTMLElement) => {
-        const height = element.getBoundingClientRect().height;
-        const key = element.getAttribute('data-key');
-        if (key) {
-          groupSizesRef.current.set(key, height);
-        }
-        return height + GROUP_SPACING;
-      }, []),
+      measureElement: useCallback(
+        (element: HTMLElement) => {
+          const height = element.getBoundingClientRect().height;
+          const index = element.getAttribute('data-index');
+          if (index) {
+            const indexNum = Number.parseInt(index, 10);
+            if (!Number.isNaN(indexNum) && filteredGroups[indexNum]) {
+              const [key] = filteredGroups[indexNum];
+              groupSizesRef.current.set(key, height);
+            }
+          }
+          return height + GROUP_SPACING;
+        },
+        [filteredGroups],
+      ),
     });
 
     /**
@@ -145,7 +152,7 @@ const GalleryContent = memo(
               return (
                 <div
                   key={key}
-                  data-key={key}
+                  data-index={virtualRow.index}
                   ref={virtualizer.measureElement}
                   style={{
                     position: 'absolute',

--- a/src/v2/components/PhotoGallery/MeasurePhotoGroup.tsx
+++ b/src/v2/components/PhotoGallery/MeasurePhotoGroup.tsx
@@ -85,7 +85,21 @@ export function MeasurePhotoGroup({
       }, 100);
     };
 
-    const resizeObserver = new ResizeObserver(handleResize);
+    let resizeObserver: ResizeObserver;
+    try {
+      resizeObserver = new ResizeObserver((entries) => {
+        try {
+          if (entries.length > 0) {
+            handleResize();
+          }
+        } catch (error) {
+          console.warn('ResizeObserver measurement error:', error);
+        }
+      });
+    } catch (error) {
+      console.warn('ResizeObserver creation failed:', error);
+      return;
+    }
     resizeObserver.observe(containerRef.current);
     setContainerWidth(containerRef.current.clientWidth);
 

--- a/src/v2/hooks/useResizeObserver.ts
+++ b/src/v2/hooks/useResizeObserver.ts
@@ -18,17 +18,41 @@ export function useResizeObserver<T extends HTMLElement>(): [
     if (!ref.current) return;
 
     const element = ref.current;
-    observerRef.current = new ResizeObserver((entries) => {
-      if (!entries[0]) return;
+    const previousSize = { width: 0, height: 0 };
 
-      const { width, height } = entries[0].contentRect;
-      setSize({ width, height });
-    });
+    try {
+      observerRef.current = new ResizeObserver((entries) => {
+        try {
+          if (!entries[0]) return;
 
-    observerRef.current.observe(element);
+          const { width, height } = entries[0].contentRect;
+
+          // Only update if the size actually changed significantly
+          const threshold = 1;
+          if (
+            Math.abs(width - previousSize.width) > threshold ||
+            Math.abs(height - previousSize.height) > threshold
+          ) {
+            previousSize.width = width;
+            previousSize.height = height;
+            setSize({ width, height });
+          }
+        } catch (error) {
+          console.warn('ResizeObserver entry processing error:', error);
+        }
+      });
+
+      observerRef.current.observe(element);
+    } catch (error) {
+      console.warn('ResizeObserver creation failed:', error);
+    }
 
     return () => {
-      observerRef.current?.disconnect();
+      try {
+        observerRef.current?.disconnect();
+      } catch (error) {
+        console.warn('ResizeObserver disconnect error:', error);
+      }
     };
   }, []);
 


### PR DESCRIPTION
Fixes #335

This PR resolves the "Uncaught ResizeObserver loop completed with undelivered notifications" errors and missing data-index attribute issues in the photo gallery.

## Changes:
- Fix data-key to data-index in GalleryContent.tsx for proper virtual element tracking
- Add ResizeObserver error handling and debouncing in MeasurePhotoGroup.tsx
- Improve useResizeObserver hook with size change thresholds and error handling

## Technical Details:
The issue was caused by a mismatch between what the @tanstack/react-virtual library expected (`data-index` attributes) and what the code was providing (`data-key` attributes). This caused measurement failures and triggered ResizeObserver loops during scrolling.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for resize observer functionality to prevent crashes and log warnings if observer creation or callbacks fail.
	- Reduced unnecessary updates by only triggering size changes when significant differences are detected.

- **Refactor**
	- Updated element identification logic in the photo gallery for more reliable measurement and alignment with group data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->