### PR TITLE
feat: Sentryイベントの個人情報マスク処理を追加

### DIFF
--- a/electron/index.ts
+++ b/electron/index.ts
@@ -1,10 +1,12 @@
 import path from 'node:path';
 import { type BrowserWindow, app, ipcMain } from 'electron';
 
-import { init as initSentry } from '@sentry/electron/main';
+import type { ErrorEvent } from '@sentry/core';
+import { type EventHint, init as initSentry } from '@sentry/electron/main';
 // Packages
 import { createIPCHandler } from 'electron-trpc/main';
 import unhandled from 'electron-unhandled';
+import { scrubEventData } from '../src/lib/utils/masking';
 import { router } from './api';
 import * as electronUtil from './electronUtil';
 import * as log from './lib/logger';
@@ -34,12 +36,15 @@ export const initializeMainSentry = () => {
     dsn: process.env.SENTRY_DSN,
     environment: process.env.NODE_ENV,
     debug: process.env.NODE_ENV !== 'production',
-    beforeSend: (event) => {
-      if (settingStore.getTermsAccepted()) {
-        return event;
+    beforeSend: (event: ErrorEvent, _hint: EventHint) => {
+      if (settingStore.getTermsAccepted() !== true) {
+        log.info('Sentry event dropped due to terms not accepted.');
+        return null;
       }
-      log.info('Sentry event dropped due to terms not accepted.');
-      return null; // 規約未同意の場合はイベントを送信しない
+
+      const processedEvent = scrubEventData(event);
+
+      return processedEvent;
     },
   });
   log.info(

--- a/src/lib/utils/masking.ts
+++ b/src/lib/utils/masking.ts
@@ -1,0 +1,71 @@
+import type { ErrorEvent } from '@sentry/core';
+
+/**
+ * 文字列中のファイルパスに含まれる可能性のあるユーザー名をマスクします。
+ * 例: /Users/username/path -> /Users/[REDACTED_USER]/path
+ *     C:\Users\username\path -> C:\Users\[REDACTED_USER]\path
+ */
+export function maskFilePaths(str: string | undefined): string | undefined {
+  if (!str) {
+    return str;
+  }
+  // macOS / Linux Paths
+  let newStr = str.replace(/(\/Users\/)[^/]+(\/)/g, '$1[REDACTED_USER]$2');
+  newStr = newStr.replace(/(\/home\/)[^/]+(\/)/g, '$1[REDACTED_USER]$2');
+  // Windows Paths
+  newStr = newStr.replace(
+    /([A-Za-z]:\\Users\\)[^\\]+(\\)/g,
+    '$1[REDACTED_USER]$2',
+  );
+  return newStr;
+}
+
+/**
+ * Sentry イベントオブジェクト内の主要な箇所に含まれるファイルパスをマスクします。
+ */
+export function scrubEventData(event: ErrorEvent): ErrorEvent {
+  // エラーメッセージ
+  if (event.message) {
+    event.message = maskFilePaths(event.message);
+  }
+
+  // 例外情報
+  if (event.exception?.values) {
+    for (const value of event.exception.values) {
+      if (value.value) {
+        value.value = maskFilePaths(value.value);
+      }
+      // スタックトレースのファイル名
+      if (value.stacktrace?.frames) {
+        for (const frame of value.stacktrace.frames) {
+          if (frame.filename) {
+            frame.filename = maskFilePaths(frame.filename);
+          }
+        }
+      }
+    }
+  }
+
+  // パンくず (Breadcrumbs)
+  if (event.breadcrumbs) {
+    for (const breadcrumb of event.breadcrumbs) {
+      if (breadcrumb.message) {
+        breadcrumb.message = maskFilePaths(breadcrumb.message);
+      }
+      // カテゴリが 'http' や 'fetch' の場合、URLも確認 (必要に応じて)
+      // if (breadcrumb.data && breadcrumb.data.url) {
+      //   breadcrumb.data.url = maskFilePaths(breadcrumb.data.url as string);
+      // }
+    }
+  }
+
+  // リクエストURL (より広範なマスクが必要な場合)
+  if (event.request?.url) {
+    event.request.url = maskFilePaths(event.request.url);
+  }
+
+  // TODO: 他にマスクが必要なフィールドがあればここに追加
+  // 例: event.extra, event.tags など
+
+  return event;
+}


### PR DESCRIPTION
- SentryのbeforeSendフックで、ユーザーが規約に同意していない場合にイベントを送信しないように変更
- 新たにscrubEventData関数を追加し、エラーメッセージやスタックトレース内のファイルパスをマスク
- utils/masking.tsにファイルパスマスク用の関数を実装


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Error reports now automatically mask user-specific file path information to enhance privacy.
- **Bug Fixes**
	- Improved filtering of error reports to ensure events are only sent if terms have been accepted.
- **Style**
	- Enhanced logging for dropped or scrubbed error events for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->