### PR TITLE
feat: 写真選択時に選択順序を表示する機能を追加

### DIFF
--- a/src/assets/licenses.json
+++ b/src/assets/licenses.json
@@ -175,11 +175,11 @@
     "path": "node_modules/@electron/get",
     "licenseFile": "node_modules/@electron/get/LICENSE"
   },
-  "@esbuild/linux-arm64@0.21.5": {
+  "@esbuild/linux-x64@0.21.5": {
     "licenses": "MIT",
     "repository": "https://github.com/evanw/esbuild",
-    "path": "node_modules/@esbuild/linux-arm64",
-    "licenseFile": "node_modules/@esbuild/linux-arm64/README.md"
+    "path": "node_modules/@esbuild/linux-x64",
+    "licenseFile": "node_modules/@esbuild/linux-x64/README.md"
   },
   "@floating-ui/core@1.7.1": {
     "licenses": "MIT",
@@ -217,21 +217,21 @@
     "path": "node_modules/@gar/promisify",
     "licenseFile": "node_modules/@gar/promisify/LICENSE.md"
   },
-  "@img/sharp-libvips-linux-arm64@1.0.2": {
+  "@img/sharp-libvips-linux-x64@1.0.2": {
     "licenses": "LGPL-3.0-or-later",
     "repository": "https://github.com/lovell/sharp-libvips",
     "publisher": "Lovell Fuller",
     "email": "npm@lovell.info",
-    "path": "node_modules/sharp/node_modules/@img/sharp-libvips-linux-arm64",
-    "licenseFile": "node_modules/sharp/node_modules/@img/sharp-libvips-linux-arm64/README.md"
+    "path": "node_modules/sharp/node_modules/@img/sharp-libvips-linux-x64",
+    "licenseFile": "node_modules/sharp/node_modules/@img/sharp-libvips-linux-x64/README.md"
   },
-  "@img/sharp-linux-arm64@0.33.3": {
+  "@img/sharp-linux-x64@0.33.3": {
     "licenses": "Apache-2.0",
     "repository": "https://github.com/lovell/sharp",
     "publisher": "Lovell Fuller",
     "email": "npm@lovell.info",
-    "path": "node_modules/sharp/node_modules/@img/sharp-linux-arm64",
-    "licenseFile": "node_modules/sharp/node_modules/@img/sharp-linux-arm64/LICENSE"
+    "path": "node_modules/sharp/node_modules/@img/sharp-linux-x64",
+    "licenseFile": "node_modules/sharp/node_modules/@img/sharp-linux-x64/LICENSE"
   },
   "@isaacs/cliui@8.0.2": {
     "licenses": "ISC",
@@ -807,12 +807,12 @@
     "path": "node_modules/@radix-ui/rect",
     "licenseFile": "node_modules/@radix-ui/rect/README.md"
   },
-  "@rollup/rollup-linux-arm64-gnu@4.43.0": {
+  "@rollup/rollup-linux-x64-gnu@4.43.0": {
     "licenses": "MIT",
     "repository": "https://github.com/rollup/rollup",
     "publisher": "Lukas Taegert-Atkinson",
-    "path": "node_modules/@rollup/rollup-linux-arm64-gnu",
-    "licenseFile": "node_modules/@rollup/rollup-linux-arm64-gnu/README.md"
+    "path": "node_modules/@rollup/rollup-linux-x64-gnu",
+    "licenseFile": "node_modules/@rollup/rollup-linux-x64-gnu/README.md"
   },
   "@sentry-internal/browser-utils@9.26.0": {
     "licenses": "MIT",
@@ -863,17 +863,17 @@
     "path": "node_modules/@sentry/bundler-plugin-core",
     "licenseFile": "node_modules/@sentry/bundler-plugin-core/LICENSE"
   },
-  "@sentry/cli-linux-arm64@2.42.2": {
+  "@sentry/cli-linux-x64@2.42.2": {
     "licenses": "BSD-3-Clause",
     "repository": "https://github.com/getsentry/sentry-cli",
-    "path": "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-linux-arm64",
-    "licenseFile": "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-linux-arm64/README.md"
+    "path": "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-linux-x64",
+    "licenseFile": "node_modules/@sentry/bundler-plugin-core/node_modules/@sentry/cli-linux-x64/README.md"
   },
-  "@sentry/cli-linux-arm64@2.46.0": {
+  "@sentry/cli-linux-x64@2.46.0": {
     "licenses": "BSD-3-Clause",
     "repository": "https://github.com/getsentry/sentry-cli",
-    "path": "node_modules/@sentry/cli-linux-arm64",
-    "licenseFile": "node_modules/@sentry/cli-linux-arm64/README.md"
+    "path": "node_modules/@sentry/cli-linux-x64",
+    "licenseFile": "node_modules/@sentry/cli-linux-x64/README.md"
   },
   "@sentry/cli@2.42.2": {
     "licenses": "BSD-3-Clause",
@@ -1577,11 +1577,11 @@
     "path": "node_modules/clean-stack",
     "licenseFile": "node_modules/clean-stack/license"
   },
-  "clip-filepaths-linux-arm64-gnu@0.2.0": {
+  "clip-filepaths-linux-x64-gnu@0.2.0": {
     "licenses": "MIT",
     "repository": "https://github.com/tktcorporation/clip-filepaths",
-    "path": "node_modules/clip-filepaths-linux-arm64-gnu",
-    "licenseFile": "node_modules/clip-filepaths-linux-arm64-gnu/README.md"
+    "path": "node_modules/clip-filepaths-linux-x64-gnu",
+    "licenseFile": "node_modules/clip-filepaths-linux-x64-gnu/README.md"
   },
   "clip-filepaths@0.2.0": {
     "licenses": "MIT",

--- a/src/v2/components/PhotoGallery.tsx
+++ b/src/v2/components/PhotoGallery.tsx
@@ -44,6 +44,8 @@ const PhotoGallery = memo((props: PhotoGalleryProps) => {
   const {
     selectedPhotos,
     setSelectedPhotos,
+    selectionOrder,
+    setSelectionOrder,
     isMultiSelectMode,
     setIsMultiSelectMode,
     groupedPhotos,
@@ -54,6 +56,7 @@ const PhotoGallery = memo((props: PhotoGalleryProps) => {
   /** 選択をクリアし、複数選択モードを解除するハンドラ */
   const handleClearSelection = () => {
     setSelectedPhotos(new Set());
+    setSelectionOrder([]);
     setIsMultiSelectMode(false);
   };
 
@@ -92,15 +95,24 @@ const PhotoGallery = memo((props: PhotoGalleryProps) => {
       return;
     }
 
-    // 選択された写真のパスを取得
-    const selectedPhotoUrls: string[] = [];
+    // 選択された写真のパスを取得（選択順序を保持）
+    const photoMap = new Map<string, string>();
 
-    // グループ内の写真からIDが一致するものを探す
+    // まず全ての写真をMapに格納
     for (const group of Object.values(groupedPhotos)) {
       for (const photo of group.photos) {
         if (selectedPhotos.has(photo.id.toString())) {
-          selectedPhotoUrls.push(photo.url);
+          photoMap.set(photo.id.toString(), photo.url);
         }
+      }
+    }
+
+    // 選択順序に従ってURLを配列に格納
+    const selectedPhotoUrls: string[] = [];
+    for (const photoId of selectionOrder) {
+      const url = photoMap.get(photoId);
+      if (url) {
+        selectedPhotoUrls.push(url);
       }
     }
 

--- a/src/v2/components/PhotoGallery/GalleryContent.tsx
+++ b/src/v2/components/PhotoGallery/GalleryContent.tsx
@@ -92,6 +92,8 @@ const GalleryContent = memo(
       groupedPhotos,
       selectedPhotos,
       setSelectedPhotos,
+      selectionOrder,
+      setSelectionOrder,
       isMultiSelectMode,
       setIsMultiSelectMode,
     } = usePhotoGallery(searchQuery, searchType, {
@@ -207,10 +209,16 @@ const GalleryContent = memo(
       ) => {
         if (event.target === containerRef.current && isMultiSelectMode) {
           setSelectedPhotos(new Set());
+          setSelectionOrder([]);
           setIsMultiSelectMode(false);
         }
       },
-      [isMultiSelectMode, setSelectedPhotos, setIsMultiSelectMode],
+      [
+        isMultiSelectMode,
+        setSelectedPhotos,
+        setSelectionOrder,
+        setIsMultiSelectMode,
+      ],
     );
 
     if (isLoadingGrouping) {
@@ -293,6 +301,8 @@ const GalleryContent = memo(
                           photos={group.photos}
                           selectedPhotos={selectedPhotos}
                           setSelectedPhotos={setSelectedPhotos}
+                          selectionOrder={selectionOrder}
+                          setSelectionOrder={setSelectionOrder}
                           isMultiSelectMode={isMultiSelectMode}
                           setIsMultiSelectMode={setIsMultiSelectMode}
                         />

--- a/src/v2/components/PhotoGallery/usePhotoGallery.ts
+++ b/src/v2/components/PhotoGallery/usePhotoGallery.ts
@@ -30,6 +30,8 @@ interface GalleryDebugInfo {
 const selectedPhotoAtom = atom<Photo | null>(null);
 /** 選択されている写真のIDセット */
 const selectedPhotosAtom = atom<Set<string>>(new Set<string>());
+/** 選択順序を記録する配列 */
+const selectionOrderAtom = atom<string[]>([]);
 /** 複数選択モードかどうか */
 const isMultiSelectModeAtom = atom<boolean>(false);
 
@@ -67,6 +69,10 @@ export function usePhotoGallery(
   setSelectedPhotos: (
     update: Set<string> | ((prev: Set<string>) => Set<string>),
   ) => void;
+  /** 選択順序を記録する配列 */
+  selectionOrder: string[];
+  /** 選択順序を更新する関数 */
+  setSelectionOrder: (order: string[]) => void;
   /** 現在複数選択モードかどうか */
   isMultiSelectMode: boolean;
   /** 複数選択モードの有効/無効を設定する関数 */
@@ -76,6 +82,7 @@ export function usePhotoGallery(
 } {
   const [selectedPhoto, setSelectedPhoto] = useAtom(selectedPhotoAtom);
   const [selectedPhotos, setSelectedPhotos] = useAtom(selectedPhotosAtom);
+  const [selectionOrder, setSelectionOrder] = useAtom(selectionOrderAtom);
   const [isMultiSelectMode, setIsMultiSelectMode] = useAtom(
     isMultiSelectModeAtom,
   );
@@ -255,6 +262,8 @@ export function usePhotoGallery(
     setSelectedPhoto,
     selectedPhotos,
     setSelectedPhotos,
+    selectionOrder,
+    setSelectionOrder,
     isMultiSelectMode,
     setIsMultiSelectMode,
     debug,

--- a/src/v2/components/PhotoGrid.tsx
+++ b/src/v2/components/PhotoGrid.tsx
@@ -17,6 +17,10 @@ interface PhotoGridProps {
   setSelectedPhotos: (
     update: Set<string> | ((prev: Set<string>) => Set<string>),
   ) => void;
+  /** 選択順序を記録する配列 */
+  selectionOrder: string[];
+  /** 選択順序を更新する関数 */
+  setSelectionOrder: (order: string[]) => void;
   /** 現在複数選択モードかどうか */
   isMultiSelectMode: boolean;
   /** 複数選択モードの有効/無効を設定する関数 */
@@ -59,6 +63,8 @@ export default function PhotoGrid({
   photos,
   selectedPhotos,
   setSelectedPhotos,
+  selectionOrder,
+  setSelectionOrder,
   isMultiSelectMode,
   setIsMultiSelectMode,
 }: PhotoGridProps) {
@@ -100,6 +106,8 @@ export default function PhotoGrid({
                       priority={index === 0}
                       selectedPhotos={selectedPhotos}
                       setSelectedPhotos={setSelectedPhotos}
+                      selectionOrder={selectionOrder}
+                      setSelectionOrder={setSelectionOrder}
                       photos={photos}
                       isMultiSelectMode={isMultiSelectMode}
                       setIsMultiSelectMode={setIsMultiSelectMode}


### PR DESCRIPTION
## Summary
- 写真を複数選択した際に、選択した順番が数字で表示されるようになりました
- 選択順序に従って写真をコピーできるようになりました

## Changes
- PhotoCardコンポーネントに選択順序を表示するUIを追加
- 選択状態管理に`selectionOrder`配列を追加し、選択順を記録
- 各コンポーネント間で選択順序のプロップスを伝達
- 写真コピー時に選択順序を保持

## Related Issue
Closes #485

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to track and display the order in which photos are selected during multi-selection mode.
  - When multiple photos are selected, a numeric badge now shows the selection sequence on each selected photo.
  - Copying selected photos now preserves and respects the order in which they were selected.

- **Chores**
  - Updated license information to reference Linux x64 packages instead of Linux ARM64 packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->