### PR TITLE
feat(#485): 写真選択時に選択順序を表示する機能を実装

### DIFF
--- a/src/v2/components/PhotoGallery.tsx
+++ b/src/v2/components/PhotoGallery.tsx
@@ -53,7 +53,7 @@ const PhotoGallery = memo((props: PhotoGalleryProps) => {
 
   /** 選択をクリアし、複数選択モードを解除するハンドラ */
   const handleClearSelection = () => {
-    setSelectedPhotos(new Set());
+    setSelectedPhotos(new Map());
     setIsMultiSelectMode(false);
   };
 
@@ -86,23 +86,34 @@ const PhotoGallery = memo((props: PhotoGalleryProps) => {
     });
 
   // 選択された写真をクリップボードにコピーするハンドラ
-  /** 選択写真のパスを集めて一括コピーする */
+  /** 選択写真のパスを集めて選択順でソートし一括コピーする */
   const handleCopySelected = () => {
     if (selectedPhotos.size === 0) {
       return;
     }
 
-    // 選択された写真のパスを取得
-    const selectedPhotoUrls: string[] = [];
+    // 選択された写真の情報を収集（IDと選択順序を保持）
+    const selectedPhotoData: Array<{ url: string; order: number }> = [];
 
     // グループ内の写真からIDが一致するものを探す
     for (const group of Object.values(groupedPhotos)) {
       for (const photo of group.photos) {
-        if (selectedPhotos.has(photo.id.toString())) {
-          selectedPhotoUrls.push(photo.url);
+        const photoIdStr = photo.id.toString();
+        if (selectedPhotos.has(photoIdStr)) {
+          const order = selectedPhotos.get(photoIdStr);
+          if (order !== undefined) {
+            selectedPhotoData.push({
+              url: photo.url,
+              order,
+            });
+          }
         }
       }
     }
+
+    // 選択順でソート
+    selectedPhotoData.sort((a, b) => a.order - b.order);
+    const selectedPhotoUrls = selectedPhotoData.map((data) => data.url);
 
     // 写真をクリップボードにコピー
     if (selectedPhotoUrls.length > 0) {

--- a/src/v2/components/PhotoGallery/GalleryContent.tsx
+++ b/src/v2/components/PhotoGallery/GalleryContent.tsx
@@ -206,7 +206,7 @@ const GalleryContent = memo(
           | React.KeyboardEvent<HTMLDivElement>,
       ) => {
         if (event.target === containerRef.current && isMultiSelectMode) {
-          setSelectedPhotos(new Set());
+          setSelectedPhotos(new Map());
           setIsMultiSelectMode(false);
         }
       },

--- a/src/v2/components/PhotoGallery/usePhotoGallery.ts
+++ b/src/v2/components/PhotoGallery/usePhotoGallery.ts
@@ -28,8 +28,8 @@ interface GalleryDebugInfo {
 
 /** 表示中の写真（モーダル表示用） */
 const selectedPhotoAtom = atom<Photo | null>(null);
-/** 選択されている写真のIDセット */
-const selectedPhotosAtom = atom<Set<string>>(new Set<string>());
+/** 選択されている写真のIDと選択順序のマップ */
+const selectedPhotosAtom = atom<Map<string, number>>(new Map<string, number>());
 /** 複数選択モードかどうか */
 const isMultiSelectModeAtom = atom<boolean>(false);
 
@@ -61,11 +61,13 @@ export function usePhotoGallery(
   selectedPhoto: Photo | null;
   /** モーダル表示する写真オブジェクトを設定する関数 */
   setSelectedPhoto: (photo: Photo | null) => void;
-  /** 現在選択されている写真のIDセット */
-  selectedPhotos: Set<string>;
-  /** 選択されている写真のIDセットを更新する関数 */
+  /** 現在選択されている写真のIDと選択順序のマップ */
+  selectedPhotos: Map<string, number>;
+  /** 選択されている写真のIDと選択順序のマップを更新する関数 */
   setSelectedPhotos: (
-    update: Set<string> | ((prev: Set<string>) => Set<string>),
+    update:
+      | Map<string, number>
+      | ((prev: Map<string, number>) => Map<string, number>),
   ) => void;
   /** 現在複数選択モードかどうか */
   isMultiSelectMode: boolean;

--- a/src/v2/components/PhotoGrid.tsx
+++ b/src/v2/components/PhotoGrid.tsx
@@ -11,11 +11,13 @@ import PhotoCard from './PhotoCard';
 interface PhotoGridProps {
   /** 表示する写真オブジェクトの配列 */
   photos: Photo[];
-  /** 現在選択されている写真のIDセット */
-  selectedPhotos: Set<string>;
-  /** 選択されている写真のIDセットを更新する関数 */
+  /** 現在選択されている写真のIDと選択順序のマップ */
+  selectedPhotos: Map<string, number>;
+  /** 選択されている写真のIDと選択順序のマップを更新する関数 */
   setSelectedPhotos: (
-    update: Set<string> | ((prev: Set<string>) => Set<string>),
+    update:
+      | Map<string, number>
+      | ((prev: Map<string, number>) => Map<string, number>),
   ) => void;
   /** 現在複数選択モードかどうか */
   isMultiSelectMode: boolean;


### PR DESCRIPTION
## 概要
フォトギャラリーで複数写真を選択する際に、選択順序を番号で表示する機能を実装しました。
これにより、TwitterやDiscordなどのSNSに投稿する際に意図した順序で表示されるようになります。

## 変更内容
1. **データ構造の変更**
   - `selectedPhotos`を`Set<string>`から`Map<string, number>`に変更
   - Mapのキーは写真ID、値は選択順序（1から始まる連番）

2. **UI/UXの改善**
   - PhotoCardコンポーネントに選択順序番号バッジを追加
   - CheckCircle2アイコンの右下に番号を表示
   - primary colorを使用した視認性の高いデザイン

3. **機能改善**
   - 写真コピー時に選択順序でソート
   - SNSへのペースト時に選択順と同じ順序で表示

## 背景
- Issue #485 にて、複数写真選択時の順序が分からない問題が報告されていました
- 特にTwitterでは最初の写真が強調表示されるため、順序管理が重要でした

## スクリーンショット
※実装後のスクリーンショットは以下のような動作になります：
- 写真を選択すると、チェックマークの右下に「1」「2」「3」...と番号が表示される
- 選択を解除すると番号も消える
- コピー時は番号順でペーストされる

## テスト結果
- ✅ `yarn lint:fix` - パス
- ✅ `yarn lint` - パス
- ✅ `yarn test` - パス

## 影響範囲
- PhotoCard: 選択番号の表示ロジック追加
- PhotoGallery: Map構造への対応
- usePhotoGallery: データ構造の変更
- PhotoGrid: 型定義の更新
- GalleryContent: Map構造への対応

closes #485

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Selection order is now tracked when selecting multiple photos, allowing users to see and maintain the order in which photos were selected.
  * Selected photos display a badge showing their selection order.

* **Enhancements**
  * When copying selected photos, they are copied in the order they were selected.

* **Bug Fixes**
  * Improved consistency in selection clearing and copying actions across the photo gallery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->