### PR TITLE
fix: improve light mode contrast by adjusting gradient and search styling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -51,9 +51,9 @@
     --radius: 0.75rem;
 
     /* Arc Browser style subtle gradient background - reduced brightness for better contrast */
-    --gradient-start: 220 15% 92%;
-    --gradient-middle: 225 12% 90%;
-    --gradient-end: 230 10% 88%;
+    --gradient-start: 220 15% 82%;
+    --gradient-middle: 225 12% 80%;
+    --gradient-end: 230 10% 78%;
     
     /* Glass effect backdrop */
     --glass-bg: 0 0% 100% / 0.1;

--- a/src/v2/components/SearchCombobox.tsx
+++ b/src/v2/components/SearchCombobox.tsx
@@ -37,7 +37,7 @@ const SearchCombobox = memo(
         <button
           type="button"
           onClick={handleOpenOverlay}
-          className={`relative flex items-center w-full h-7 bg-white/60 dark:bg-gray-900/40 backdrop-blur-xl rounded-2xl border-0 px-4 py-2 text-sm font-medium transition-all duration-300 hover:bg-white/70 dark:hover:bg-gray-900/50 hover:shadow-md hover:shadow-black/5 dark:hover:shadow-white/5 ${
+          className={`relative flex items-center w-full h-7 backdrop-blur-xl rounded-2xl border-2 border-solid border-border text-foreground px-4 py-2 text-sm font-medium transition-all duration-300 hover:border-ring hover:shadow-md hover:shadow-black/5 dark:hover:shadow-white/5 ${
             className || ''
           }`}
           aria-label="検索を開く"

--- a/src/v2/components/SearchOverlay.tsx
+++ b/src/v2/components/SearchOverlay.tsx
@@ -235,7 +235,7 @@ const SearchOverlay = memo(
       >
         <div className="absolute top-0 left-0 right-0 p-4 pointer-events-none">
           <div
-            className="max-w-2xl mx-auto bg-white/95 dark:bg-gray-900/95 backdrop-blur-2xl rounded-2xl border border-gray-200/20 dark:border-gray-700/30 shadow-2xl pointer-events-auto"
+            className="max-w-2xl mx-auto bg-white/85 dark:bg-gray-900/85 backdrop-blur-2xl rounded-2xl border border-gray-200/20 dark:border-gray-700/30 shadow-2xl pointer-events-auto"
             onClick={(e) => e.stopPropagation()}
             onKeyDown={(e) => e.stopPropagation()}
           >


### PR DESCRIPTION
- Reduce gradient lightness values by 10% for better contrast
  - gradient-start: 92% → 82%
  - gradient-middle: 90% → 80% 
  - gradient-end: 88% → 78%
- Remove search button background, add border and text color
- Reduce search overlay opacity from 95% to 85%

Resolves #576

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reduced brightness of gradient background colors in light theme for a softer appearance.
  * Updated search trigger button styling with a visible border and adjusted hover effect.
  * Lowered background opacity in the search overlay for a subtler visual effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->