### PR TITLE
fix: GitHub Actionsワークフローの依存関係インストール処理を統一

### DIFF
--- a/.github/actions/setup-node-and-install/action.yml
+++ b/.github/actions/setup-node-and-install/action.yml
@@ -1,0 +1,29 @@
+name: 'Setup Node.js and Install Dependencies'
+description: 'Common setup for Node.js and dependency installation'
+inputs:
+  node-version:
+    description: 'Node.js version to use (defaults to reading from package.json)'
+    required: false
+    default: ''
+  working-directory:
+    description: 'Working directory for the installation'
+    required: false
+    default: '.'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: ${{ inputs.node-version == '' && 'package.json' || '' }}
+        node-version: ${{ inputs.node-version != '' && inputs.node-version || '' }}
+
+    - name: Install ni globally
+      shell: bash
+      run: npm i -g @antfu/ni
+
+    - name: Install dependencies with ni
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: nci

--- a/.github/workflows/deploy-landing-page.yml
+++ b/.github/workflows/deploy-landing-page.yml
@@ -22,22 +22,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Install dependencies
-        run: yarn install
-
-      - name: Install landing page dependencies
-        run: yarn workspace @vrchat-albums/landing-page install
+      - name: Setup Node and Install Dependencies
+        uses: ./.github/actions/setup-node-and-install
 
       - name: Build landing page
-        run: yarn build:landing
+        run: nr build:landing
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -15,15 +15,8 @@ jobs:
         - name: Checkout code
           uses: actions/checkout@v4
     
-        - name: setup node
-          uses: actions/setup-node@v4
-          with:
-            node-version-file: 'package.json'
-    
-        - run: npm i -g @antfu/ni
-        
-        - name: install dependencies
-          run: nci
+        - name: Setup Node and Install Dependencies
+          uses: ./.github/actions/setup-node-and-install
         
         - name: run license-checker
           run: |

--- a/.github/workflows/lint-test-cross.yml
+++ b/.github/workflows/lint-test-cross.yml
@@ -11,15 +11,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: 'package.json'
-
-      - run: npm i -g @antfu/ni
-      
-      - name: install dependencies
-        run: nci
+      - name: Setup Node and Install Dependencies
+        uses: ./.github/actions/setup-node-and-install
 
       - name: lint
         run: nr lint
@@ -34,15 +27,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: 'package.json'
-
-      - run: npm i -g @antfu/ni
-      
-      - name: install dependencies
-        run: nci
+      - name: Setup Node and Install Dependencies
+        uses: ./.github/actions/setup-node-and-install
 
       - name: test
         run: nr test

--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -14,15 +14,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: 'package.json'
-
-      - run: npm i -g @antfu/ni
-
-      - name: Install dependencies
-        run: nci
+      - name: Setup Node and Install Dependencies
+        uses: ./.github/actions/setup-node-and-install
 
       - name: build app
         run: nr build

--- a/.github/workflows/tag-on-push.yml
+++ b/.github/workflows/tag-on-push.yml
@@ -15,15 +15,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: 'package.json'
-
-      - run: npm i -g @antfu/ni
-
-      - name: install dependencies
-        run: nci
+      - name: Setup Node and Install Dependencies
+        uses: ./.github/actions/setup-node-and-install
 
       - name: lint
         run: nr lint

--- a/.github/workflows/upload-build-files.yml
+++ b/.github/workflows/upload-build-files.yml
@@ -104,15 +104,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: 'package.json'
-
-      - run: npm i -g @antfu/ni
-
-      - name: Install dependencies
-        run: nci
+      - name: Setup Node and Install Dependencies
+        uses: ./.github/actions/setup-node-and-install
 
       - name: Build and Publish Electron App
         env:


### PR DESCRIPTION
## 概要
GitHub Actionsワークフローで依存関係のインストール処理が統一されていなかったため、デプロイランディングページのCIでエラーが発生していた問題を修正しました。

## 問題点
- `deploy-landing-page.yml`では直接`yarn install`を使用していたが、他のワークフローでは`@antfu/ni`を使用
- Yarn 4のCorepack処理に不整合があり、mainブランチへのマージ時にビルドが失敗

## 解決策
1. 新しいcomposite action `setup-node-and-install`を作成
2. すべてのワークフローで統一的な依存関係インストール処理を実装
3. `@antfu/ni`を標準的に使用することで、パッケージマネージャーの違いを吸収

## 変更内容
- `.github/actions/setup-node-and-install/action.yml` - 新規作成
- 以下のワークフローを更新:
  - `deploy-landing-page.yml`
  - `lint-test-cross.yml`
  - `tag-on-push.yml`
  - `upload-build-files.yml`
  - `screenshot.yml`
  - `license-checker.yml`

## テスト結果
- [x] yarn lint:fix 実行済み
- [x] yarn lint 成功
- [x] 各ワークフローで同じセットアップ手順を使用するよう統一

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a reusable action to set up Node.js and install dependencies, now used across CI workflows.
  * Simplified build, lint, test, deploy, license check, tagging, and screenshot pipelines for consistency and speed.
  * Updated the landing page build step to use the standardized project script.
  * Adjusted screenshot workflow permissions to enable necessary content updates.
  * Overall CI maintenance improves reliability, reduces duplication, and streamlines future workflow changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->