### PR TITLE
Keep types/node synced with Node version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@
   </architecture>
 
   <environment>
-    <nodejs>20 LTS</nodejs>
+    <nodejs>22 LTS</nodejs>
     <package-manager>Yarn 4 (npm禁止)</package-manager>
   </environment>
 

--- a/package.json
+++ b/package.json
@@ -53,12 +53,13 @@
     "test:playwright": "run-s build \"playwright:setup-and-run\" sync-landing-images",
     "playwright:setup-and-run": "playwright install --with-deps && playwright test --timeout=60000",
     "sync-landing-images": "bash scripts/sync-landing-images.sh",
-    "lint": "run-p lint:biome lint:type-check lint:actionlint lint:valueobjects lint:neverthrow lint:grit",
+    "lint": "run-p lint:biome lint:type-check lint:actionlint lint:valueobjects lint:neverthrow lint:grit lint:node-types",
     "lint:valueobjects": "tsx scripts/lint-valueobjects.ts",
     "lint:valueobjects:grit": "run-p \"lint:valueobjects:grit:*\"",
     "lint:valueobjects:grit:export": "grit apply valueobject_export electron/ src/ --dry-run",
     "lint:valueobjects:grit:schema": "grit apply valueobject_schema electron/ src/ --dry-run",
     "lint:neverthrow": "tsx scripts/lint-neverthrow.ts",
+    "lint:node-types": "tsx scripts/lint-node-types.ts",
     "lint:neverthrow:grit": "run-p \"lint:neverthrow:grit:*\"",
     "lint:neverthrow:grit:async": "grit apply neverthrow_async electron/module/**/service.ts --dry-run",
     "lint:neverthrow:grit:catch": "grit apply neverthrow_catch electron/module/**/service.ts --dry-run",
@@ -87,7 +88,7 @@
   },
   "packageManager": "yarn@4.1.0",
   "engines": {
-    "node": ">=20",
+    "node": "22",
     "yarn": "4"
   },
   "dependencies": {
@@ -164,7 +165,7 @@
     "@tktco/node-actionlint": "~1.6.0",
     "@types/electron-is-dev": "1.1.3",
     "@types/license-checker": "25.0.6",
-    "@types/node": "~24.0.0",
+    "@types/node": "~22.17.0",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@types/sharp": "0.32.0",

--- a/scripts/lint-node-types.ts
+++ b/scripts/lint-node-types.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+import { createRequire } from 'node:module';
+import consola from 'consola';
+
+const require = createRequire(import.meta.url);
+const pkg = require('../package.json') as {
+  engines?: { node?: string };
+  devDependencies?: Record<string, string>;
+};
+
+function extractMajorVersion(version: string): string | null {
+  // Handle patterns like "20", "^20.0.0", "~20.17.2", ">=20", "20.x"
+  const match = version.match(/(\d+)/);
+  return match ? match[1] : null;
+}
+
+function main(): void {
+  consola.start('Checking @types/node version matches engines.node...');
+
+  const enginesNode = pkg.engines?.node;
+  const typesNode = pkg.devDependencies?.['@types/node'];
+
+  if (!enginesNode) {
+    consola.error('engines.node is not defined in package.json');
+    process.exit(1);
+  }
+
+  if (!typesNode) {
+    consola.error('@types/node is not defined in devDependencies');
+    process.exit(1);
+  }
+
+  const enginesMajor = extractMajorVersion(enginesNode);
+  const typesMajor = extractMajorVersion(typesNode);
+
+  if (!enginesMajor) {
+    consola.error(`Cannot parse engines.node version: ${enginesNode}`);
+    process.exit(1);
+  }
+
+  if (!typesMajor) {
+    consola.error(`Cannot parse @types/node version: ${typesNode}`);
+    process.exit(1);
+  }
+
+  if (enginesMajor !== typesMajor) {
+    consola.error(
+      `Version mismatch: @types/node@${typesNode} (major: ${typesMajor}) does not match engines.node: "${enginesNode}" (major: ${enginesMajor})`,
+    );
+    consola.info(`Fix: yarn add -D @types/node@~${enginesMajor}.0.0`);
+    process.exit(1);
+  }
+
+  consola.success(
+    `@types/node@${typesNode} matches engines.node: "${enginesNode}"`,
+  );
+}
+
+main();

--- a/src/assets/licenses.json
+++ b/src/assets/licenses.json
@@ -1303,17 +1303,17 @@
     "path": "node_modules/@types/mysql",
     "licenseFile": "node_modules/@types/mysql/LICENSE"
   },
+  "@types/node@22.17.2": {
+    "licenses": "MIT",
+    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+    "path": "node_modules/@types/node",
+    "licenseFile": "node_modules/@types/node/LICENSE"
+  },
   "@types/node@22.19.3": {
     "licenses": "MIT",
     "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
     "path": "node_modules/electron/node_modules/@types/node",
     "licenseFile": "node_modules/electron/node_modules/@types/node/LICENSE"
-  },
-  "@types/node@24.0.15": {
-    "licenses": "MIT",
-    "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
-    "path": "node_modules/@types/node",
-    "licenseFile": "node_modules/@types/node/LICENSE"
   },
   "@types/node@24.0.3": {
     "licenses": "MIT",
@@ -5327,14 +5327,14 @@
   "undici-types@6.21.0": {
     "licenses": "MIT",
     "repository": "https://github.com/nodejs/undici",
-    "path": "node_modules/electron/node_modules/undici-types",
-    "licenseFile": "node_modules/electron/node_modules/undici-types/LICENSE"
+    "path": "node_modules/undici-types",
+    "licenseFile": "node_modules/undici-types/LICENSE"
   },
   "undici-types@7.8.0": {
     "licenses": "MIT",
     "repository": "https://github.com/nodejs/undici",
-    "path": "node_modules/undici-types",
-    "licenseFile": "node_modules/undici-types/LICENSE"
+    "path": "node_modules/@types/connect/node_modules/undici-types",
+    "licenseFile": "node_modules/@types/connect/node_modules/undici-types/LICENSE"
   },
   "undici@6.22.0": {
     "licenses": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4757,12 +4757,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:~24.0.0":
-  version: 24.0.15
-  resolution: "@types/node@npm:24.0.15"
+"@types/node@npm:~22.17.0":
+  version: 22.17.2
+  resolution: "@types/node@npm:22.17.2"
   dependencies:
-    undici-types: "npm:~7.8.0"
-  checksum: 10c0/39ead0c0ff25dde29357630b5eaa7dd73cf3af796dbd0f01ed439a8af01cbddfa6b68aa9d67fb3243962836170a4463ff856c47fa822250c585987f707eb42b3
+    undici-types: "npm:~6.21.0"
+  checksum: 10c0/23cd13aa35da6322a6d66cf4b3a45dbd40764ba726ab8681960270156c3abba776dd8dc173250c467f708d40612ecd725755d7659b775b513904680d5205eaff
   languageName: node
   linkType: hard
 
@@ -14172,7 +14172,7 @@ __metadata:
     "@trpc/server": "npm:10.45.2"
     "@types/electron-is-dev": "npm:1.1.3"
     "@types/license-checker": "npm:25.0.6"
-    "@types/node": "npm:~24.0.0"
+    "@types/node": "npm:~22.17.0"
     "@types/react": "npm:^19.2.7"
     "@types/react-dom": "npm:^19.2.3"
     "@types/sharp": "npm:0.32.0"


### PR DESCRIPTION
Summary
@types/node のバージョンが package.json の engines.node と一致することを検証する lint スクリプトを追加
engines.node を "22" に固定（">=20" から変更）
@types/node を ~22.17.0 に設定（~24.0.0 から変更、engines と同期）
変更内容
ファイル	変更
scripts/lint-node-types.ts	新規: メジャーバージョン一致を検証するスクリプト
package.json	lint:node-types スクリプト追加、yarn lint に統合
package.json	engines.node: ">=20" → "22"
package.json	@types/node: ~24.0.0 → ~22.17.0
CLAUDE.md	環境設定を Node.js 22 LTS に更新
動作
$ yarn lint:node-types
✔ @types/node@~22.17.0 matches engines.node: "22"

不一致時:

$ yarn lint:node-types
✖ Version mismatch: @types/node@~24.0.0 (major: 24) does not match engines.node: "22" (major: 22)
ℹ Fix: yarn add -D @types/node@~22.0.0

Test plan
 yarn lint:node-types が正常に動作
 yarn lint に統合され、全体の lint で検証される
 yarn lint:fix が通る

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added validation script to ensure consistency between Node.js runtime and type definitions.

* **Chores**
  * Upgraded Node.js runtime requirement from 20 LTS to 22 LTS.
  * Updated Node.js type definitions to align with new runtime version.
  * Refreshed license metadata mappings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->