### PR TITLE
Fix failing test in VRChat albums

### DIFF
--- a/src/v2/components/settings/DataExport.test.tsx
+++ b/src/v2/components/settings/DataExport.test.tsx
@@ -124,10 +124,10 @@ describe('DataExport', () => {
     // useEffect完了を待つ - outputPathが設定されるまで待機
     await waitFor(
       () => {
-        const exportButton = screen.getByRole('button', {
-          name: 'エクスポート開始',
-        });
-        expect((exportButton as HTMLButtonElement).disabled).toBe(false);
+        const outputPathInput = screen.getByLabelText(/出力先ディレクトリ/);
+        expect((outputPathInput as HTMLInputElement).value).toBe(
+          '/home/user/Downloads',
+        );
       },
       { timeout: 3000 },
     );
@@ -152,10 +152,10 @@ describe('DataExport', () => {
     // useEffectの完了を待つ - outputPathが設定されるまで待機
     await waitFor(
       () => {
-        const exportButton = screen.getByRole('button', {
-          name: 'エクスポート開始',
-        });
-        expect((exportButton as HTMLButtonElement).disabled).toBe(false);
+        const outputPathInput = screen.getByLabelText(/出力先ディレクトリ/);
+        expect((outputPathInput as HTMLInputElement).value).toBe(
+          '/home/user/Downloads',
+        );
       },
       { timeout: 3000 },
     );
@@ -193,10 +193,10 @@ describe('DataExport', () => {
     // useEffectの完了を待つ - outputPathが設定されるまで待機
     await waitFor(
       () => {
-        const exportButton = screen.getByRole('button', {
-          name: 'エクスポート開始',
-        });
-        expect((exportButton as HTMLButtonElement).disabled).toBe(false);
+        const outputPathInput = screen.getByLabelText(/出力先ディレクトリ/);
+        expect((outputPathInput as HTMLInputElement).value).toBe(
+          '/home/user/Downloads',
+        );
       },
       { timeout: 3000 },
     );


### PR DESCRIPTION
The tests were failing because they checked if the export button was enabled, but that didn't depend on outputPath being set. The async getDownloadsPath.query() hadn't resolved yet, causing outputPath to be undefined.

Changed waitFor to check the actual outputPath input value instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions to verify output path input values instead of export button state across multiple scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->