### PR TITLE
fix: レイアウトシフト対策 - Immich方式スケルトン実装とアニメーション削除

### DIFF
--- a/src/v2/components/GroupWithSkeleton.tsx
+++ b/src/v2/components/GroupWithSkeleton.tsx
@@ -1,0 +1,113 @@
+import { useMemo } from 'react';
+import { useContainerWidth } from '../hooks/useContainerWidth';
+import type { Photo } from '../types/photo';
+import { JustifiedLayoutCalculator } from '../utils/justifiedLayoutCalculator';
+import { LocationGroupHeader } from './LocationGroupHeader';
+
+/**
+ * GroupWithSkeleton コンポーネントのプロパティ定義
+ */
+interface GroupWithSkeletonProps {
+  /** グループ内の写真配列（PhotoMetadataOnly でも可） */
+  photos: Photo[];
+  /** ワールドID */
+  worldId: string | null;
+  /** ワールド名 */
+  worldName: string | null;
+  /** ワールドインスタンスID */
+  worldInstanceId: string | null;
+  /** 写真数 */
+  photoCount: number;
+  /** ワールド参加日時 */
+  joinDateTime: Date;
+}
+
+/**
+ * Immich方式のスケルトンコンポーネント
+ *
+ * ## 設計原則
+ *
+ * JustifiedLayoutCalculator を使用して、実際の写真と**同じ高さ**で
+ * スケルトンボックスを配置する。これにより、スケルトン→実コンテンツの
+ * 切り替え時にレイアウトシフトが発生しない。
+ *
+ * ## Immich との比較
+ *
+ * - Immich: `monthGroup.height` をスケルトンと実コンテンツで共有
+ * - VRChat Albums: `JustifiedLayoutCalculator.calculateLayout()` の結果を共有
+ *
+ * ## PhotoMetadataOnly の活用
+ *
+ * Photo 型は `PhotoMetadataOnly | PhotoFullyLoaded` のユニオン型。
+ * PhotoMetadataOnly にも `width`, `height` が含まれているため、
+ * 画像ロード前でも正確なレイアウト計算が可能。
+ *
+ * @see JustifiedLayoutCalculator - レイアウト計算
+ * @see PhotoGrid - 実際の写真表示（同じレイアウト計算を使用）
+ */
+export function GroupWithSkeleton({
+  photos,
+  worldId,
+  worldName,
+  worldInstanceId,
+  photoCount,
+  joinDateTime,
+}: GroupWithSkeletonProps) {
+  const { containerRef, containerWidth } = useContainerWidth();
+  const calculator = useMemo(() => new JustifiedLayoutCalculator(), []);
+
+  // PhotoGrid と同じレイアウト計算を使用
+  const layout = useMemo(() => {
+    if (containerWidth === 0 || photos.length === 0) {
+      return { rows: [], totalHeight: 0 };
+    }
+    return calculator.calculateLayout(photos, containerWidth);
+  }, [calculator, photos, containerWidth]);
+
+  return (
+    <div ref={containerRef} className="w-full space-y-0">
+      {/* 実際のヘッダー（スケルトンではない） */}
+      <LocationGroupHeader
+        worldId={worldId}
+        worldName={worldName}
+        worldInstanceId={worldInstanceId}
+        photoCount={photoCount}
+        joinDateTime={joinDateTime}
+      />
+
+      {/* JustifiedLayout で計算された位置にスケルトンボックスを配置 */}
+      {photos.length > 0 && (
+        <div className="w-full rounded-b-lg overflow-hidden">
+          <div className="space-y-1">
+            {layout.rows.map((row, rowIndex) => {
+              const rowKey = `skeleton-row-${rowIndex}-${row[0]?.id ?? rowIndex}`;
+              return (
+                <div
+                  key={rowKey}
+                  className="flex gap-1"
+                  style={{
+                    height: row[0]?.displayHeight ?? 200,
+                  }}
+                >
+                  {row.map((photo, index) => {
+                    const photoKey = `skeleton-${rowIndex}-${photo.id}-${index}`;
+                    return (
+                      <div
+                        key={photoKey}
+                        style={{
+                          width: photo.displayWidth,
+                          flexShrink: 0,
+                        }}
+                        className="bg-gray-200 dark:bg-gray-700 rounded animate-pulse"
+                      />
+                    );
+                  })}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/v2/components/LocationGroupHeader/index.tsx
+++ b/src/v2/components/LocationGroupHeader/index.tsx
@@ -201,7 +201,7 @@ export const LocationGroupHeader = ({
     return (
       <header
         data-testid="location-group-header"
-        className={`w-full glass-panel rounded-t-xl ${SPACING.padding.section} animate-glass-morph`}
+        className={`w-full glass-panel rounded-t-xl ${SPACING.padding.section}`}
       >
         <div className={`flex items-center ${SPACING.inline.relaxed}`}>
           <h2 className={`text-xl font-bold ${TEXT_COLOR.primary}`}>
@@ -222,7 +222,7 @@ export const LocationGroupHeader = ({
     <div
       ref={containerRef}
       data-testid="location-group-header"
-      className="w-full glass-panel rounded-t-lg overflow-hidden transition-all duration-500 group/card animate-glass-morph"
+      className="w-full glass-panel rounded-t-lg overflow-hidden group/card"
     >
       <div className="relative h-24 overflow-hidden flex items-center justify-center">
         <div

--- a/src/v2/components/PhotoGrid.tsx
+++ b/src/v2/components/PhotoGrid.tsx
@@ -1,4 +1,3 @@
-import clsx from 'clsx';
 import { useMemo } from 'react';
 import { useContainerWidth } from '../hooks/useContainerWidth';
 import type { Photo } from '../types/photo';
@@ -96,7 +95,7 @@ export default function PhotoGrid({
                       width: photo.displayWidth,
                       flexShrink: 0,
                     }}
-                    className={clsx('relative transition-all duration-300')}
+                    className="relative"
                   >
                     <PhotoCard
                       photo={photo}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -89,26 +89,6 @@ module.exports = {
           from: { height: 'var(--radix-accordion-content-height)' },
           to: { height: '0' },
         },
-        'glass-morph': {
-          '0%': {
-            opacity: '0',
-            transform: 'translateY(20px) scale(0.95)',
-            backdropFilter: 'blur(0px)',
-          },
-          '100%': {
-            opacity: '1',
-            transform: 'translateY(0) scale(1)',
-            backdropFilter: 'blur(20px)',
-          },
-        },
-        'glass-hover': {
-          '0%': { transform: 'translateY(0)' },
-          '100%': { transform: 'translateY(-2px)' },
-        },
-        'glass-shine': {
-          '0%': { transform: 'translateX(-100%)' },
-          '100%': { transform: 'translateX(100%)' },
-        },
         'gradient-x': {
           '0%, 100%': {
             'background-size': '200% 200%',
@@ -123,9 +103,6 @@ module.exports = {
       animation: {
         'accordion-down': 'accordion-down 0.2s ease-out',
         'accordion-up': 'accordion-up 0.2s ease-out',
-        'glass-morph': 'glass-morph 0.6s ease-out',
-        'glass-hover': 'glass-hover 0.2s ease-out',
-        'glass-shine': 'glass-shine 2s ease-in-out infinite',
         'gradient-x': 'gradient-x 3s ease infinite',
       },
       backdropBlur: {


### PR DESCRIPTION
## Summary

- Immich方式のスケルトン実装により、スケルトン→実コンテンツ切り替え時のレイアウトシフトを解消
- 出現アニメーション（glass-morph, transition-all）を削除してレイアウト安定性を向上

## 変更内容

### 1. GroupWithSkeleton コンポーネント (新規)
- `JustifiedLayoutCalculator` を使用してスケルトンの位置を計算
- `PhotoGrid` と**同じレイアウト計算**を使用 → 高さが一致しレイアウトシフトなし
- `PhotoMetadataOnly` の width/height を活用してロード前に正確なレイアウト計算

### 2. GalleryContent の簡略化
- 3状態分岐 → 2状態分岐
  - `isGroupFullyLoaded`: `PhotoGrid` を表示
  - else: `GroupWithSkeleton` を表示（写真なしも統一処理）

### 3. 出現アニメーションの削除
| ファイル | 削除内容 |
|---------|---------|
| `LocationGroupHeader` | `animate-glass-morph`, `transition-all duration-500` |
| `PhotoGrid` | `transition-all duration-300` |
| `tailwind.config.js` | `glass-morph`, `glass-hover`, `glass-shine` keyframes |

## 設計背景

Immich の実装パターンを参考:
```svelte
{#if !monthGroup.isLoaded}
  <Skeleton height={monthGroup.height} />  <!-- 同じ高さ -->
{:else}
  <Month ... />                             <!-- 同じ高さ -->
{/if}
```

VRChat Albums では `PhotoMetadataOnly` に既に width/height が含まれているため、ロード前でも正確な JustifiedLayout を計算可能。

## Test plan

- [ ] ギャラリーをスクロールしてレイアウトシフトがないことを確認
- [ ] スケルトン→実コンテンツ切り替え時に高さが変わらないことを確認
- [ ] LocationGroupHeader が即座に表示されることを確認
- [ ] 写真0枚のグループでもヘッダーが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Loading states now display animated skeleton placeholders that match the actual photo layout for better visual consistency during content loading.

* **Style**
  * Removed glass morphism animations for a cleaner, more straightforward interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->