### PR TITLE
perf: Rust部分読み込みで写真インデックスの画像サイズ取得を高速化

### DIFF
--- a/.changeset/fast-image-dimensions.md
+++ b/.changeset/fast-image-dimensions.md
@@ -1,0 +1,5 @@
+---
+'vrchat-albums': patch
+---
+
+写真インデックスの画像サイズ取得を高速化: Rust 部分読み込み + Rayon 並列化で Transformer.metadata() を置き換え

--- a/electron/lib/sharpConfig.ts
+++ b/electron/lib/sharpConfig.ts
@@ -10,7 +10,7 @@
  * - electron/index.ts での早期初期化（GLib-GObject 競合回避）
  * - concurrency / cache の手動設定
  *
- * この薄いラッパーは、既存コードの initializeSharp() / clearSharpCache() /
+ * この薄いラッパーは、既存コードの initializeSharp() /
  * isSharpInitialized() 呼び出しとの互換性を維持するために残している。
  * 将来的に呼び出し元が不要と判断されれば削除可能。
  */
@@ -31,14 +31,4 @@ export const initializeSharp = (): void => {
  */
 export const isSharpInitialized = (): boolean => {
   return isInitialized;
-};
-
-/**
- * キャッシュクリア（互換性のためのno-op）
- *
- * napi-rs/image にはグローバルキャッシュがないため何もしない。
- * 呼び出し元がこの関数を使わなくなれば削除可能。
- */
-export const clearSharpCache = (): void => {
-  // no-op: @napi-rs/image has no global cache to clear
 };

--- a/electron/lib/wrappedExifTool.ts
+++ b/electron/lib/wrappedExifTool.ts
@@ -9,6 +9,7 @@
 
 import type {
   JsExifWriteParams,
+  JsImageDimensions,
   JsVrcXmpMetadata,
 } from '@vrchat-albums/exif-native';
 import { Data, Effect } from 'effect';
@@ -50,6 +51,10 @@ interface ExifNativeModule {
   writeExif(filePath: string, params: JsExifWriteParams): void;
   writeExifToBuffer(buffer: Buffer, params: JsExifWriteParams): Buffer;
   detectImageFormatJs(buffer: Buffer): string;
+  readImageDimensions(filePath: string): JsImageDimensions | null;
+  readImageDimensionsBatch(
+    filePaths: string[],
+  ): (JsImageDimensions | null | undefined)[];
 }
 
 let _exifNative: ExifNativeModule | null = null;
@@ -191,6 +196,27 @@ export const setExifToBuffer = (
       });
     },
   });
+
+// ============================================================================
+// 画像サイズ取得
+// ============================================================================
+
+/**
+ * 複数ファイルから画像サイズ（width/height）をバッチ読み取り。
+ *
+ * 背景: 写真インデックスでは width/height だけが必要だが、
+ * 従来は @napi-rs/image の Transformer でファイル全体をデコードしていた。
+ * Rust ネイティブモジュールでファイルの先頭バイトだけを読み取り、
+ * Rayon でスレッドプール並列化することで 10〜50 倍の高速化を実現する。
+ *
+ * 呼び出し元: processPhotoBatch() (vrchatPhoto.service.ts)
+ */
+export const readImageDimensionsBatch = (
+  filePaths: string[],
+): (JsImageDimensions | null | undefined)[] => {
+  const native = getExifNative();
+  return native.readImageDimensionsBatch(filePaths);
+};
 
 // ============================================================================
 // ライフサイクル管理（exif-native では不要だが、既存の呼び出し元との互換性のため残す）

--- a/electron/module/vrchatPhoto/vrchatPhoto.service.test.ts
+++ b/electron/module/vrchatPhoto/vrchatPhoto.service.test.ts
@@ -29,6 +29,15 @@ vi.mock('@napi-rs/image', () => {
   }
   return { Transformer: MockTransformer };
 });
+vi.mock('./../../lib/wrappedExifTool', () => ({
+  readImageDimensionsBatch: vi
+    .fn()
+    .mockReturnValue([{ width: 1920, height: 1080 }]),
+  readXmpTags: vi.fn(),
+  writeDateTimeWithTimezone: vi.fn(),
+  setExifToBuffer: vi.fn(),
+  closeExiftoolInstance: vi.fn(),
+}));
 vi.mock('./../../lib/logger', () => ({
   logger: {
     debug: vi.fn(),
@@ -40,6 +49,8 @@ vi.mock('./../../lib/logger', () => ({
 
 // hash-wasm のインポート
 import { xxhash128 } from 'hash-wasm';
+
+import { readImageDimensionsBatch } from './../../lib/wrappedExifTool';
 
 /**
  * ファイル名リストからモックダイジェストを生成（hash-wasm モック用）
@@ -219,9 +230,14 @@ describe('createVRChatPhotoPathIndex', () => {
       >;
     });
 
-    // readFile モック - 画像処理エンジン（@napi-rs/image）用のダミーバッファを返す
+    // readFile モック - サムネイル生成（@napi-rs/image）用のダミーバッファを返す
     vi.mocked(nodefsPromises.readFile).mockResolvedValue(
       Buffer.from('fake_image_data'),
+    );
+
+    // readImageDimensionsBatch モック - 渡されたパス数に応じて結果を返す
+    vi.mocked(readImageDimensionsBatch).mockImplementation((paths) =>
+      paths.map(() => ({ width: 1920, height: 1080 })),
     );
 
     // DB model モック

--- a/electron/module/vrchatPhoto/vrchatPhoto.service.test.ts
+++ b/electron/module/vrchatPhoto/vrchatPhoto.service.test.ts
@@ -778,11 +778,11 @@ describe('createVRChatPhotoPathIndex', () => {
     });
 
     describe('readImageDimensionsBatch エラー', () => {
-      it('null が返った写真はスキップしてDB保存しない', async () => {
+      it('null が返った写真はデフォルトサイズ(1920x1080)でDB保存する', async () => {
         // file1Path の dimensions だけ null を返す
         vi.mocked(readImageDimensionsBatch).mockImplementation((paths) =>
           paths.map((p) =>
-            p.includes(file1Name) ? null : { width: 1920, height: 1080 },
+            p.includes(file1Name) ? null : { width: 3840, height: 2160 },
           ),
         );
 
@@ -791,21 +791,53 @@ describe('createVRChatPhotoPathIndex', () => {
         const allSavedData = vi
           .mocked(model.createOrUpdateListVRChatPhotoPath)
           .mock.calls.flatMap((call) => call[0]);
-        const savedPaths = allSavedData.map((d) => d.photoPath);
 
-        // file1Path は null なのでスキップ
-        expect(savedPaths).not.toContain(file1Path);
-        // 他のファイルは正常に処理
-        expect(savedPaths).toContain(file2Path);
-        expect(savedPaths).toContain(extraFilePath);
+        // file1Path はデフォルトサイズで保存される（スキップされない）
+        const file1Data = allSavedData.find((d) => d.photoPath === file1Path);
+        expect(file1Data).toBeDefined();
+        expect(file1Data?.width).toBe(1920);
+        expect(file1Data?.height).toBe(1080);
+
+        // 他のファイルは正常なサイズで処理
+        const file2Data = allSavedData.find((d) => d.photoPath === file2Path);
+        expect(file2Data?.width).toBe(3840);
+        expect(file2Data?.height).toBe(2160);
       });
 
-      it('全て null が返った場合はDB保存が呼ばれない', async () => {
+      it('全て null が返った場合もデフォルトサイズでDB保存する', async () => {
         vi.mocked(readImageDimensionsBatch).mockReturnValue([null, null, null]);
 
         await service.createVRChatPhotoPathIndex(false);
 
-        expect(model.createOrUpdateListVRChatPhotoPath).not.toHaveBeenCalled();
+        // 全てデフォルトサイズで保存される
+        expect(model.createOrUpdateListVRChatPhotoPath).toHaveBeenCalled();
+        const allSavedData = vi
+          .mocked(model.createOrUpdateListVRChatPhotoPath)
+          .mock.calls.flatMap((call) => call[0]);
+        for (const data of allSavedData) {
+          expect(data.width).toBe(1920);
+          expect(data.height).toBe(1080);
+        }
+      });
+
+      it('undefined が返った写真もデフォルトサイズでDB保存する', async () => {
+        vi.mocked(readImageDimensionsBatch).mockImplementation((paths) =>
+          paths.map((p) =>
+            p.includes(file1Name) ? undefined : { width: 1920, height: 1080 },
+          ),
+        );
+
+        await service.createVRChatPhotoPathIndex(false);
+
+        const allSavedData = vi
+          .mocked(model.createOrUpdateListVRChatPhotoPath)
+          .mock.calls.flatMap((call) => call[0]);
+
+        // file1Path もデフォルトサイズで保存される
+        const file1Data = allSavedData.find((d) => d.photoPath === file1Path);
+        expect(file1Data).toBeDefined();
+        expect(file1Data?.width).toBe(1920);
+        expect(file1Data?.height).toBe(1080);
       });
     });
   });

--- a/electron/module/vrchatPhoto/vrchatPhoto.service.test.ts
+++ b/electron/module/vrchatPhoto/vrchatPhoto.service.test.ts
@@ -776,5 +776,37 @@ describe('createVRChatPhotoPathIndex', () => {
         );
       });
     });
+
+    describe('readImageDimensionsBatch エラー', () => {
+      it('null が返った写真はスキップしてDB保存しない', async () => {
+        // file1Path の dimensions だけ null を返す
+        vi.mocked(readImageDimensionsBatch).mockImplementation((paths) =>
+          paths.map((p) =>
+            p.includes(file1Name) ? null : { width: 1920, height: 1080 },
+          ),
+        );
+
+        await service.createVRChatPhotoPathIndex(false);
+
+        const allSavedData = vi
+          .mocked(model.createOrUpdateListVRChatPhotoPath)
+          .mock.calls.flatMap((call) => call[0]);
+        const savedPaths = allSavedData.map((d) => d.photoPath);
+
+        // file1Path は null なのでスキップ
+        expect(savedPaths).not.toContain(file1Path);
+        // 他のファイルは正常に処理
+        expect(savedPaths).toContain(file2Path);
+        expect(savedPaths).toContain(extraFilePath);
+      });
+
+      it('全て null が返った場合はDB保存が呼ばれない', async () => {
+        vi.mocked(readImageDimensionsBatch).mockReturnValue([null, null, null]);
+
+        await service.createVRChatPhotoPathIndex(false);
+
+        expect(model.createOrUpdateListVRChatPhotoPath).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/electron/module/vrchatPhoto/vrchatPhoto.service.ts
+++ b/electron/module/vrchatPhoto/vrchatPhoto.service.ts
@@ -1089,7 +1089,7 @@ function processPhotoBatch(
   }[] = [];
   for (let i = 0; i < pathsWithDates.length; i++) {
     const dim = dimensions[i];
-    if (dim == null) {
+    if (dim === null || dim === undefined) {
       logger.debug({
         message: 'Failed to read image dimensions, skipping',
         details: { photoPath: pathsWithDates[i].photoPath },

--- a/electron/module/vrchatPhoto/vrchatPhoto.service.ts
+++ b/electron/module/vrchatPhoto/vrchatPhoto.service.ts
@@ -1080,7 +1080,13 @@ function processPhotoBatch(
     pathsWithDates.map((p) => p.photoPath),
   );
 
-  // Step 3: 結合（null はスキップ — ファイル未検出、権限エラー、破損ヘッダー等）
+  // Step 3: 結合（null はデフォルトサイズでフォールバック）
+  // 背景: ファイル未検出・権限エラー・破損ヘッダー等で null が返る場合でも、
+  // 写真の存在自体はインデックスに残す。サイズが不明な場合は VRChat のデフォルト解像度を使用。
+  // DB に写真が登録されないとギャラリーに表示されなくなるため、スキップより保存を優先。
+  const DEFAULT_WIDTH = 1920;
+  const DEFAULT_HEIGHT = 1080;
+
   const results: {
     photoPath: string;
     takenAt: Date;
@@ -1091,16 +1097,20 @@ function processPhotoBatch(
     const dim = dimensions[i];
     if (dim === null || dim === undefined) {
       logger.debug({
-        message: 'Failed to read image dimensions, skipping',
-        details: { photoPath: pathsWithDates[i].photoPath },
+        message:
+          'Failed to read image dimensions, using default size for indexing',
+        details: {
+          photoPath: pathsWithDates[i].photoPath,
+          defaultWidth: DEFAULT_WIDTH,
+          defaultHeight: DEFAULT_HEIGHT,
+        },
       });
-      continue;
     }
     results.push({
       photoPath: pathsWithDates[i].photoPath,
       takenAt: pathsWithDates[i].takenAt,
-      width: dim.width,
-      height: dim.height,
+      width: dim?.width ?? DEFAULT_WIDTH,
+      height: dim?.height ?? DEFAULT_HEIGHT,
     });
   }
 

--- a/electron/module/vrchatPhoto/vrchatPhoto.service.ts
+++ b/electron/module/vrchatPhoto/vrchatPhoto.service.ts
@@ -28,11 +28,8 @@ import {
   MemoryMonitor,
   PARALLEL_LIMITS,
 } from './../../lib/memoryMonitor';
-import {
-  clearSharpCache,
-  initializeSharp,
-  isSharpInitialized,
-} from './../../lib/sharpConfig';
+import { initializeSharp, isSharpInitialized } from './../../lib/sharpConfig';
+import { readImageDimensionsBatch } from './../../lib/wrappedExifTool';
 import * as fs from './../../lib/wrappedFs';
 import * as model from './model/vrchatPhotoPath.model';
 import {
@@ -1044,156 +1041,67 @@ const filterNewFilesByMtime = async (
 
 /**
  * 写真情報のバッチを処理する
- * メモリ効率を考慮し、並列処理数を制限
  *
- * ## メモリ最適化
- * - 並列数を5に制限（libvipsのネイティブメモリ使用を抑制）
- * - RSS監視で圧迫時に遅延
- * - サブバッチ間でキャッシュをクリア
+ * 背景: Rust ネイティブモジュール (exif-native) でファイルの先頭バイトだけを
+ * 部分読み込みし、Rayon でスレッドプール並列化することで高速に width/height を取得する。
+ * 従来は @napi-rs/image の Transformer でファイル全体をデコードしていたが、
+ * 画像サイズだけなら PNG の IHDR (24B) / JPEG の SOF マーカーで十分。
  */
-async function processPhotoBatch(
+function processPhotoBatch(
   photoPaths: string[],
-  memoryMonitor?: MemoryMonitor,
-): Promise<
-  { photoPath: string; takenAt: Date; width: number; height: number }[]
-> {
+): { photoPath: string; takenAt: Date; width: number; height: number }[] {
+  // Step 1: ファイル名から takenAt をパース（I/O なし）
+  const pathsWithDates: { photoPath: string; takenAt: Date }[] = [];
+  for (const photoPath of photoPaths) {
+    const matchResult = photoPath.match(
+      /VRChat_(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.\d{3})/,
+    );
+    if (!matchResult) {
+      logger.debug({
+        message: 'Photo filename did not match expected pattern, skipping',
+        details: { photoPath },
+      });
+      continue;
+    }
+    const takenAt = dateFns.parse(
+      matchResult[1],
+      'yyyy-MM-dd_HH-mm-ss.SSS',
+      new Date(),
+    );
+    pathsWithDates.push({ photoPath, takenAt });
+  }
+
+  if (pathsWithDates.length === 0) {
+    return [];
+  }
+
+  // Step 2: Rust バッチで画像サイズ取得（rayon 並列、先頭バイトのみ読み込み）
+  const dimensions = readImageDimensionsBatch(
+    pathsWithDates.map((p) => p.photoPath),
+  );
+
+  // Step 3: 結合（null はスキップ — ファイル未検出、権限エラー、破損ヘッダー等）
   const results: {
     photoPath: string;
     takenAt: Date;
     width: number;
     height: number;
   }[] = [];
-
-  // 並列処理数をメモリ使用量に基づいて動的に決定
-  const monitor = memoryMonitor ?? getGlobalMemoryMonitor();
-  const parallelLimit = monitor.getRecommendedParallelLimit(
-    PARALLEL_LIMITS.sharpMetadata,
-  );
-
-  for (let i = 0; i < photoPaths.length; i += parallelLimit) {
-    const subBatch = photoPaths.slice(i, i + parallelLimit);
-
-    // メモリ監視
-    await monitor.checkMemory(
-      `processPhotoBatch subBatch ${Math.floor(i / parallelLimit) + 1}`,
-    );
-
-    const photoInfoPromises = subBatch.map(async (photoPath) => {
-      const matchResult = photoPath.match(
-        /VRChat_(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}\.\d{3})/,
-      );
-      if (!matchResult) {
-        // VRChat写真のファイル名パターンにマッチしない場合
-        // これは通常発生しないが、ファイル名が破損している可能性がある
-        logger.debug({
-          message: 'Photo filename did not match expected pattern, skipping',
-          details: { photoPath },
-        });
-        return null;
-      }
-
-      const takenAt = dateFns.parse(
-        matchResult[1],
-        'yyyy-MM-dd_HH-mm-ss.SSS',
-        new Date(),
-      );
-
-      // Transformerインスタンスを使い捨てにしてメモリリークを防ぐ
-      const metadataEither = await Effect.runPromise(
-        Effect.either(
-          Effect.tryPromise({
-            try: () =>
-              fsPromises.readFile(photoPath).then(async (buf) => {
-                const transformer = new Transformer(buf);
-                return transformer.metadata();
-              }),
-            catch: (error): { type: 'SHARP_ERROR'; message: string } => {
-              const nodeError = error as NodeJS.ErrnoException;
-              return match(nodeError.code)
-                .with('ENOENT', () => {
-                  // ファイル削除はレースコンディションで想定される
-                  logger.debug(
-                    `Photo file not found during metadata extraction: ${photoPath}`,
-                  );
-                  return {
-                    type: 'SHARP_ERROR' as const,
-                    message: 'File not found',
-                  };
-                })
-                .with(P.union('EACCES', 'EPERM'), () => {
-                  // 権限エラー → ユーザーに通知すべき
-                  logger.warn({
-                    message: `Permission denied reading photo: ${photoPath}`,
-                    stack:
-                      error instanceof Error ? error : new Error(String(error)),
-                  });
-                  return {
-                    type: 'SHARP_ERROR' as const,
-                    message: nodeError.message ?? 'Permission denied',
-                  };
-                })
-                .otherwise(() => {
-                  // 画像処理の内部エラー、破損ファイル等 → Sentry送信のため再スロー
-                  // デバッグのためファイルパス情報を付加
-                  const contextualError = new Error(
-                    `Image processing failed for: ${photoPath}`,
-                    { cause: error },
-                  );
-                  throw contextualError;
-                });
-            },
-          }),
-        ),
-      );
-
-      if (metadataEither._tag === 'Left') {
-        return null;
-      }
-
-      const metadata = metadataEither.right;
-      const height = metadata.height ?? 720;
-      const width = metadata.width ?? 1280;
-
-      // メタデータが不完全な場合は警告ログを出力（デバッグ用）
-      if (!metadata.height || !metadata.width) {
-        logger.warn({
-          message: `Missing dimension metadata for photo, using defaults`,
-          details: {
-            photoPath,
-            hasHeight: Boolean(metadata.height),
-            hasWidth: Boolean(metadata.width),
-            defaultsUsed: { height, width },
-          },
-        });
-      }
-
-      return {
-        photoPath,
-        takenAt,
-        width,
-        height,
-      };
-    });
-
-    const resolvedPhotoInfos = await Promise.all(photoInfoPromises);
-    const subResults = resolvedPhotoInfos.filter(
-      (
-        info,
-      ): info is {
-        photoPath: string;
-        takenAt: Date;
-        width: number;
-        height: number;
-      } => info !== null,
-    );
-
-    results.push(...subResults);
-
-    // サブバッチ処理後にキャッシュをクリア（メモリ解放）
-    // 大量処理時のメモリ蓄積を防ぐ
-    if (photoPaths.length > PHOTO_METADATA_BATCH_SIZE) {
-      clearSharpCache();
+  for (let i = 0; i < pathsWithDates.length; i++) {
+    const dim = dimensions[i];
+    if (dim == null) {
+      logger.debug({
+        message: 'Failed to read image dimensions, skipping',
+        details: { photoPath: pathsWithDates[i].photoPath },
+      });
+      continue;
     }
+    results.push({
+      photoPath: pathsWithDates[i].photoPath,
+      takenAt: pathsWithDates[i].takenAt,
+      width: dim.width,
+      height: dim.height,
+    });
   }
 
   return results;
@@ -1339,7 +1247,7 @@ export const createVRChatPhotoPathIndex = async (isIncremental = true) => {
           await memoryMonitor.checkMemory(`batch ${batchNumber} start`);
 
           const batchStartTime = performance.now();
-          const processedBatch = await processPhotoBatch(batch, memoryMonitor);
+          const processedBatch = processPhotoBatch(batch);
 
           if (processedBatch.length > 0) {
             const dbStartTime = performance.now();
@@ -1389,9 +1297,6 @@ export const createVRChatPhotoPathIndex = async (isIncremental = true) => {
               `Batch ${batchNumber}: Processed ${processedBatch.length} photos in ${(batchEndTime - batchStartTime).toFixed(2)} ms (metadata: ${(dbStartTime - batchStartTime).toFixed(2)} ms, DB: ${(dbEndTime - dbStartTime).toFixed(2)} ms)`,
             );
           }
-
-          // バッチ処理後にキャッシュをクリア（メモリ解放）
-          clearSharpCache();
         }
 
         // フォルダスキャン状態を更新

--- a/packages/exif-native/package.json
+++ b/packages/exif-native/package.json
@@ -9,6 +9,9 @@
     "build:debug": "napi build --platform",
     "prepare": "which napi > /dev/null 2>&1 && napi build --platform || true"
   },
+  "devDependencies": {
+    "@napi-rs/cli": "^3.6.1"
+  },
   "napi": {
     "binaryName": "exif-native",
     "targets": [

--- a/packages/exif-native/src/dimensions.rs
+++ b/packages/exif-native/src/dimensions.rs
@@ -21,7 +21,9 @@ pub struct ImageDimensions {
 const PNG_MIN_BYTES: usize = 24;
 
 /// JPEG の SOF マーカーを探すために読み込む最大バイト数。
-/// APP1(EXIF) が最大 64KB 程度になることがあるため、余裕を持って 64KB。
+/// APP1(EXIF) が最大 65533B になることがあるため、64KB + 余裕分を確保。
+/// 制約: SOF が 65536B 以降にある JPEG（複数の大きなメタデータセグメント）は
+/// 未対応だが、VRChat 写真の実用範囲では十分。
 const JPEG_SCAN_BYTES: usize = 65536;
 
 /// PNG バイト列の先頭から width/height を読み取る。
@@ -94,8 +96,11 @@ pub fn read_jpeg_dimensions(data: &[u8]) -> Result<ImageDimensions, String> {
         let marker = data[offset];
         offset += 1;
 
-        // SOF0-SOF3: フレームヘッダー（画像サイズを含む）
-        if (0xC0..=0xC3).contains(&marker) {
+        // SOF マーカー: フレームヘッダー（画像サイズを含む）
+        // SOF0-3 (baseline/extended/progressive/lossless),
+        // SOF5-7 (differential), SOF9-11 (arithmetic), SOF13-15 (differential arithmetic)
+        // 0xC4 (DHT), 0xC8 (JPG), 0xCC (DAC) は寸法を持たないため除外
+        if matches!(marker, 0xC0..=0xC3 | 0xC5..=0xC7 | 0xC9..=0xCB | 0xCD..=0xCF) {
             // SOF payload: length(2B) + precision(1B) + height(2B) + width(2B)
             if offset + 7 > data.len() {
                 return Err("JPEG data truncated: SOF marker too short".to_string());
@@ -162,7 +167,9 @@ pub fn read_image_dimensions_from_file(file_path: &str) -> Result<ImageDimension
             let mut buf = vec![0u8; JPEG_SCAN_BYTES];
             buf[..8].copy_from_slice(&header);
             // ファイルが 64KB 未満でも OK（読めた分だけで判定）
-            let n = file.read(&mut buf[8..]).unwrap_or(0);
+            let n = file
+                .read(&mut buf[8..])
+                .map_err(|e| format!("Failed to read JPEG data from {file_path}: {e}"))?;
             buf.truncate(8 + n);
             read_jpeg_dimensions(&buf)
         }
@@ -328,6 +335,34 @@ mod tests {
             ImageDimensions {
                 width: 1280,
                 height: 720
+            }
+        );
+    }
+
+    #[test]
+    fn reads_jpeg_sof9_arithmetic() {
+        // SOF9 (arithmetic coding) もフレームヘッダーとして認識される
+        let data = build_jpeg_with_sof(640, 480, 0xC9, &[]);
+        let dim = read_jpeg_dimensions(&data).unwrap();
+        assert_eq!(
+            dim,
+            ImageDimensions {
+                width: 640,
+                height: 480
+            }
+        );
+    }
+
+    #[test]
+    fn reads_jpeg_sof13_differential_arithmetic() {
+        // SOF13 (differential arithmetic) もフレームヘッダーとして認識される
+        let data = build_jpeg_with_sof(800, 600, 0xCD, &[]);
+        let dim = read_jpeg_dimensions(&data).unwrap();
+        assert_eq!(
+            dim,
+            ImageDimensions {
+                width: 800,
+                height: 600
             }
         );
     }

--- a/packages/exif-native/src/dimensions.rs
+++ b/packages/exif-native/src/dimensions.rs
@@ -5,7 +5,7 @@
 /// PNG なら先頭 24 バイト、JPEG なら SOF マーカーまでの数 KB で十分なため、
 /// 部分読み込みで 10〜50 倍の高速化を実現する。
 use std::fs::File;
-use std::io::Read;
+use std::io::{Read, Seek, SeekFrom};
 
 use crate::detect::{detect_image_format, ImageFormat};
 
@@ -20,11 +20,10 @@ pub struct ImageDimensions {
 /// signature(8) + chunk_length(4) + "IHDR"(4) + width(4) + height(4) = 24
 const PNG_MIN_BYTES: usize = 24;
 
-/// JPEG の SOF マーカーを探すために読み込む最大バイト数。
-/// APP1(EXIF) が最大 65533B になることがあるため、64KB + 余裕分を確保。
-/// 制約: SOF が 65536B 以降にある JPEG（複数の大きなメタデータセグメント）は
-/// 未対応だが、VRChat 写真の実用範囲では十分。
-const JPEG_SCAN_BYTES: usize = 65536;
+/// JPEG の SOF マーカーを探すためにファイルから一括読み込みする最大バイト数。
+/// SOF がこの範囲内に見つからない場合、マーカーの length を使って
+/// ファイルを seek してスキャンを続行する（上限なし）。
+const JPEG_INITIAL_READ_BYTES: usize = 65536;
 
 /// PNG バイト列の先頭から width/height を読み取る。
 ///
@@ -163,19 +162,98 @@ pub fn read_image_dimensions_from_file(file_path: &str) -> Result<ImageDimension
             read_png_dimensions(&buf)
         }
         ImageFormat::Jpeg => {
-            // JPEG: 先頭 64KB を読む（SOF は通常この範囲内にある）
-            let mut buf = vec![0u8; JPEG_SCAN_BYTES];
+            // JPEG: まず先頭 64KB を一括読み込みして SOF を探す（大半はここで見つかる）
+            let mut buf = vec![0u8; JPEG_INITIAL_READ_BYTES];
             buf[..8].copy_from_slice(&header);
-            // ファイルが 64KB 未満でも OK（読めた分だけで判定）
             let n = file
                 .read(&mut buf[8..])
                 .map_err(|e| format!("Failed to read JPEG data from {file_path}: {e}"))?;
             buf.truncate(8 + n);
-            read_jpeg_dimensions(&buf)
+
+            match read_jpeg_dimensions(&buf) {
+                Ok(dim) => Ok(dim),
+                Err(_) if 8 + n >= JPEG_INITIAL_READ_BYTES => {
+                    // 64KB で見つからなかった場合、マーカーベースで seek して続行
+                    // SOF が大きなメタデータセグメント群の後にある場合に対応
+                    read_jpeg_dimensions_from_file_seek(&mut file, file_path)
+                }
+                Err(e) => Err(e), // ファイルが 64KB 未満で見つからなかった → 本当にない
+            }
         }
         ImageFormat::Unknown => {
             Err(format!("Unknown image format: {file_path}"))
         }
+    }
+}
+
+/// JPEG ファイルをマーカーごとに seek してSOF を探す（フォールバック）。
+///
+/// 背景: 先頭 64KB の一括読み込みで SOF が見つからなかった場合に呼ばれる。
+/// 大きな APP1 (EXIF) や複数の APPn セグメントがある場合に対応する。
+/// ファイルの先頭（SOI の直後）から seek を開始する。
+fn read_jpeg_dimensions_from_file_seek(
+    file: &mut File,
+    file_path: &str,
+) -> Result<ImageDimensions, String> {
+    // SOI の直後（offset 2）から開始
+    file.seek(SeekFrom::Start(2))
+        .map_err(|e| format!("Failed to seek in {file_path}: {e}"))?;
+
+    let mut marker_buf = [0u8; 2];
+    let mut length_buf = [0u8; 2];
+    // SOF ペイロード: length(2) + precision(1) + height(2) + width(2) = 7 bytes
+    let mut sof_buf = [0u8; 7];
+
+    loop {
+        // マーカー（0xFF + type）を読む
+        file.read_exact(&mut marker_buf)
+            .map_err(|e| format!("Failed to read JPEG marker from {file_path}: {e}"))?;
+
+        if marker_buf[0] != 0xFF {
+            return Err(format!(
+                "Invalid JPEG marker in {file_path}: expected 0xFF, got 0x{:02X}",
+                marker_buf[0]
+            ));
+        }
+
+        // 0xFF パディングをスキップ
+        let mut marker_type = marker_buf[1];
+        while marker_type == 0xFF {
+            let mut single = [0u8; 1];
+            file.read_exact(&mut single)
+                .map_err(|e| format!("Failed to read JPEG marker from {file_path}: {e}"))?;
+            marker_type = single[0];
+        }
+
+        // SOF マーカー
+        if matches!(marker_type, 0xC0..=0xC3 | 0xC5..=0xC7 | 0xC9..=0xCB | 0xCD..=0xCF) {
+            file.read_exact(&mut sof_buf)
+                .map_err(|e| format!("Failed to read SOF data from {file_path}: {e}"))?;
+            let height = u16::from_be_bytes([sof_buf[3], sof_buf[4]]) as u32;
+            let width = u16::from_be_bytes([sof_buf[5], sof_buf[6]]) as u32;
+            return Ok(ImageDimensions { width, height });
+        }
+
+        // SOS / EOI → 打ち切り
+        if marker_type == 0xDA || marker_type == 0xD9 {
+            return Err(format!("SOF marker not found in {file_path}"));
+        }
+
+        // スタンドアロンマーカー
+        if (0xD0..=0xD7).contains(&marker_type) || marker_type == 0x01 {
+            continue;
+        }
+
+        // length を読んでスキップ
+        file.read_exact(&mut length_buf)
+            .map_err(|e| format!("Failed to read marker length from {file_path}: {e}"))?;
+        let length = u16::from_be_bytes(length_buf) as u64;
+        if length < 2 {
+            return Err(format!("Invalid marker length in {file_path}"));
+        }
+        // length にはlength フィールド自体の 2 バイトを含むので、残り length-2 バイトをスキップ
+        file.seek(SeekFrom::Current((length - 2) as i64))
+            .map_err(|e| format!("Failed to seek past marker in {file_path}: {e}"))?;
     }
 }
 
@@ -450,6 +528,58 @@ mod tests {
         let result = read_jpeg_dimensions(&[0xFF]);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("too short"));
+    }
+
+    // ========================================================================
+    // 境界値テスト
+    // ========================================================================
+
+    #[test]
+    fn reads_png_zero_dimensions() {
+        // 0x0 画像は PNG 仕様上は不正だが、パーサーはバイトをそのまま読む
+        let data = build_png_header(0, 0);
+        let dim = read_png_dimensions(&data).unwrap();
+        assert_eq!(dim, ImageDimensions { width: 0, height: 0 });
+    }
+
+    #[test]
+    fn reads_jpeg_zero_height_in_sof() {
+        // DNL JPEG: SOF の height が 0（後から DNL マーカーで設定される仕様）
+        // パーサーは height=0 をそのまま返す
+        let data = build_jpeg_with_sof(1920, 0, 0xC0, &[]);
+        let dim = read_jpeg_dimensions(&data).unwrap();
+        assert_eq!(dim, ImageDimensions { width: 1920, height: 0 });
+    }
+
+    #[test]
+    fn skips_c8_jpg_extension_marker_and_finds_sof0() {
+        // 0xC8 (JPG extension) は SOF ではない — length 付きマーカーとしてスキップされる
+        let mut data = Vec::new();
+        data.extend_from_slice(&[0xFF, 0xD8]); // SOI
+        // 0xC8 marker with dummy payload
+        data.extend_from_slice(&[0xFF, 0xC8]);
+        data.extend_from_slice(&[0x00, 0x04]); // length=4 (2 for length + 2 dummy)
+        data.extend_from_slice(&[0x00, 0x00]); // dummy data
+        // SOF0
+        data.push(0xFF);
+        data.push(0xC0);
+        let sof_length: u16 = 11;
+        data.extend_from_slice(&sof_length.to_be_bytes());
+        data.push(8); // precision
+        data.extend_from_slice(&1080u16.to_be_bytes()); // height
+        data.extend_from_slice(&1920u16.to_be_bytes()); // width
+        data.push(1);
+        data.extend_from_slice(&[0, 0x11, 0]);
+        data.extend_from_slice(&[0xFF, 0xD9]); // EOI
+
+        let dim = read_jpeg_dimensions(&data).unwrap();
+        assert_eq!(
+            dim,
+            ImageDimensions {
+                width: 1920,
+                height: 1080
+            }
+        );
     }
 
     // ========================================================================

--- a/packages/exif-native/src/dimensions.rs
+++ b/packages/exif-native/src/dimensions.rs
@@ -1,0 +1,494 @@
+/// 画像ファイルの先頭バイトだけを読み取り、width/height を高速に取得する。
+///
+/// 背景: 写真インデックスでは画像の width/height だけが必要だが、
+/// 従来は @napi-rs/image の Transformer でファイル全体をデコードしていた。
+/// PNG なら先頭 24 バイト、JPEG なら SOF マーカーまでの数 KB で十分なため、
+/// 部分読み込みで 10〜50 倍の高速化を実現する。
+use std::fs::File;
+use std::io::Read;
+
+use crate::detect::{detect_image_format, ImageFormat};
+
+/// 画像の幅と高さ
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ImageDimensions {
+    pub width: u32,
+    pub height: u32,
+}
+
+/// PNG の IHDR チャンクに必要な最小バイト数。
+/// signature(8) + chunk_length(4) + "IHDR"(4) + width(4) + height(4) = 24
+const PNG_MIN_BYTES: usize = 24;
+
+/// JPEG の SOF マーカーを探すために読み込む最大バイト数。
+/// APP1(EXIF) が最大 64KB 程度になることがあるため、余裕を持って 64KB。
+const JPEG_SCAN_BYTES: usize = 65536;
+
+/// PNG バイト列の先頭から width/height を読み取る。
+///
+/// PNG 仕様では、シグネチャの直後に必ず IHDR チャンクが来る。
+/// IHDR のデータ部先頭 8 バイトが width(4B, big-endian) + height(4B, big-endian)。
+pub fn read_png_dimensions(data: &[u8]) -> Result<ImageDimensions, String> {
+    if data.len() < PNG_MIN_BYTES {
+        return Err(format!(
+            "PNG data too short: {} bytes (need at least {})",
+            data.len(),
+            PNG_MIN_BYTES
+        ));
+    }
+
+    // PNG signature check (8 bytes)
+    const PNG_SIG: [u8; 8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+    if data[..8] != PNG_SIG {
+        return Err("Not a valid PNG: signature mismatch".to_string());
+    }
+
+    // Bytes 8-11: IHDR chunk length (should be 13)
+    // Bytes 12-15: chunk type (should be "IHDR")
+    if &data[12..16] != b"IHDR" {
+        return Err("Not a valid PNG: first chunk is not IHDR".to_string());
+    }
+
+    // Bytes 16-19: width (big-endian u32)
+    let width = u32::from_be_bytes([data[16], data[17], data[18], data[19]]);
+    // Bytes 20-23: height (big-endian u32)
+    let height = u32::from_be_bytes([data[20], data[21], data[22], data[23]]);
+
+    Ok(ImageDimensions { width, height })
+}
+
+/// JPEG バイト列から SOF マーカーをスキャンして width/height を読み取る。
+///
+/// SOF0 (0xC0), SOF1 (0xC1), SOF2 (0xC2), SOF3 (0xC3) を対象とする。
+/// SOF ペイロード: precision(1B) + height(2B, big-endian) + width(2B, big-endian)
+pub fn read_jpeg_dimensions(data: &[u8]) -> Result<ImageDimensions, String> {
+    if data.len() < 2 {
+        return Err("JPEG data too short".to_string());
+    }
+
+    // SOI marker check
+    if data[0] != 0xFF || data[1] != 0xD8 {
+        return Err("Not a valid JPEG: SOI marker (FFD8) not found".to_string());
+    }
+
+    let mut offset = 2;
+
+    while offset < data.len() {
+        // マーカーは 0xFF で始まる
+        if data[offset] != 0xFF {
+            return Err(format!(
+                "Invalid JPEG: expected 0xFF marker at offset {}",
+                offset
+            ));
+        }
+
+        // 0xFF のパディングをスキップ（JPEG 仕様で複数の 0xFF が許容される）
+        while offset < data.len() && data[offset] == 0xFF {
+            offset += 1;
+        }
+
+        if offset >= data.len() {
+            return Err("JPEG data truncated: no marker type after 0xFF".to_string());
+        }
+
+        let marker = data[offset];
+        offset += 1;
+
+        // SOF0-SOF3: フレームヘッダー（画像サイズを含む）
+        if (0xC0..=0xC3).contains(&marker) {
+            // SOF payload: length(2B) + precision(1B) + height(2B) + width(2B)
+            if offset + 7 > data.len() {
+                return Err("JPEG data truncated: SOF marker too short".to_string());
+            }
+            // skip length(2B) + precision(1B) = 3 bytes
+            let height = u16::from_be_bytes([data[offset + 3], data[offset + 4]]) as u32;
+            let width = u16::from_be_bytes([data[offset + 5], data[offset + 6]]) as u32;
+            return Ok(ImageDimensions { width, height });
+        }
+
+        // SOS (0xDA) / EOI (0xD9): 画像データに入ったので打ち切り
+        if marker == 0xDA || marker == 0xD9 {
+            return Err("JPEG: SOF marker not found before SOS/EOI".to_string());
+        }
+
+        // スタンドアロンマーカー（length フィールドなし）: RST0-RST7, TEM
+        if (0xD0..=0xD7).contains(&marker) || marker == 0x01 {
+            continue;
+        }
+
+        // その他のマーカー: length(2B) を読んでスキップ
+        if offset + 2 > data.len() {
+            return Err("JPEG data truncated: cannot read marker length".to_string());
+        }
+        let length = u16::from_be_bytes([data[offset], data[offset + 1]]) as usize;
+        if length < 2 {
+            return Err(format!(
+                "Invalid JPEG marker length {} at offset {}",
+                length,
+                offset - 1
+            ));
+        }
+        offset += length;
+    }
+
+    Err("JPEG: SOF marker not found".to_string())
+}
+
+/// ファイルパスから画像サイズを部分読み込みで取得する。
+///
+/// PNG: 先頭 24 バイトのみ読み込み
+/// JPEG: 先頭 64KB を読み込み → SOF マーカースキャン
+/// 不明なフォーマットはエラーを返す。
+pub fn read_image_dimensions_from_file(file_path: &str) -> Result<ImageDimensions, String> {
+    let mut file = File::open(file_path)
+        .map_err(|e| format!("Failed to open file {file_path}: {e}"))?;
+
+    // まず先頭 8 バイトを読んでフォーマット判定
+    let mut header = [0u8; 8];
+    file.read_exact(&mut header)
+        .map_err(|e| format!("Failed to read header from {file_path}: {e}"))?;
+
+    match detect_image_format(&header) {
+        ImageFormat::Png => {
+            // PNG: 残り 16 バイトを追加で読む（合計 24 バイト）
+            let mut buf = [0u8; PNG_MIN_BYTES];
+            buf[..8].copy_from_slice(&header);
+            file.read_exact(&mut buf[8..])
+                .map_err(|e| format!("Failed to read PNG IHDR from {file_path}: {e}"))?;
+            read_png_dimensions(&buf)
+        }
+        ImageFormat::Jpeg => {
+            // JPEG: 先頭 64KB を読む（SOF は通常この範囲内にある）
+            let mut buf = vec![0u8; JPEG_SCAN_BYTES];
+            buf[..8].copy_from_slice(&header);
+            // ファイルが 64KB 未満でも OK（読めた分だけで判定）
+            let n = file.read(&mut buf[8..]).unwrap_or(0);
+            buf.truncate(8 + n);
+            read_jpeg_dimensions(&buf)
+        }
+        ImageFormat::Unknown => {
+            Err(format!("Unknown image format: {file_path}"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    // ========================================================================
+    // テストヘルパー
+    // ========================================================================
+
+    /// 指定サイズの最小 PNG IHDR バイト列を構築する（signature + IHDR チャンク先頭部分）
+    fn build_png_header(width: u32, height: u32) -> Vec<u8> {
+        let mut buf = Vec::new();
+        // PNG signature
+        buf.extend_from_slice(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+        // IHDR chunk: length = 13
+        buf.extend_from_slice(&13u32.to_be_bytes());
+        // chunk type
+        buf.extend_from_slice(b"IHDR");
+        // width, height
+        buf.extend_from_slice(&width.to_be_bytes());
+        buf.extend_from_slice(&height.to_be_bytes());
+        buf
+    }
+
+    /// 最小限の JPEG バイト列を構築（SOI + 任意マーカー + SOF0 + EOI）
+    fn build_jpeg_with_sof(
+        width: u16,
+        height: u16,
+        sof_marker: u8,
+        prefix_segments: &[(u8, &[u8])],
+    ) -> Vec<u8> {
+        let mut buf = Vec::new();
+        // SOI
+        buf.extend_from_slice(&[0xFF, 0xD8]);
+
+        // prefix segments (e.g., APP0, APP1)
+        for (marker, data) in prefix_segments {
+            buf.push(0xFF);
+            buf.push(*marker);
+            let length = (data.len() + 2) as u16;
+            buf.extend_from_slice(&length.to_be_bytes());
+            buf.extend_from_slice(data);
+        }
+
+        // SOF marker
+        buf.push(0xFF);
+        buf.push(sof_marker);
+        // SOF length: 2 (length) + 1 (precision) + 2 (height) + 2 (width) + 1 (components) + 3*components
+        // 最小: 8 + 3 = 11, ここでは 11 を使用（1 component）
+        let sof_length: u16 = 11;
+        buf.extend_from_slice(&sof_length.to_be_bytes());
+        buf.push(8); // precision
+        buf.extend_from_slice(&height.to_be_bytes());
+        buf.extend_from_slice(&width.to_be_bytes());
+        buf.push(1); // number of components
+        buf.extend_from_slice(&[0, 0x11, 0]); // component spec
+
+        // EOI
+        buf.extend_from_slice(&[0xFF, 0xD9]);
+
+        buf
+    }
+
+    // ========================================================================
+    // PNG テスト
+    // ========================================================================
+
+    #[test]
+    fn reads_png_1x1() {
+        let data = build_png_header(1, 1);
+        let dim = read_png_dimensions(&data).unwrap();
+        assert_eq!(dim, ImageDimensions { width: 1, height: 1 });
+    }
+
+    #[test]
+    fn reads_png_1920x1080() {
+        let data = build_png_header(1920, 1080);
+        let dim = read_png_dimensions(&data).unwrap();
+        assert_eq!(
+            dim,
+            ImageDimensions {
+                width: 1920,
+                height: 1080
+            }
+        );
+    }
+
+    #[test]
+    fn reads_png_4096x2048() {
+        let data = build_png_header(4096, 2048);
+        let dim = read_png_dimensions(&data).unwrap();
+        assert_eq!(
+            dim,
+            ImageDimensions {
+                width: 4096,
+                height: 2048
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_png_short_data() {
+        let data = [0x89, 0x50, 0x4E, 0x47]; // only 4 bytes
+        let result = read_png_dimensions(&data);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("too short"));
+    }
+
+    #[test]
+    fn rejects_png_wrong_magic() {
+        let mut data = build_png_header(100, 100);
+        data[0] = 0x00; // corrupt signature
+        let result = read_png_dimensions(&data);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("signature mismatch"));
+    }
+
+    #[test]
+    fn rejects_png_non_ihdr_first_chunk() {
+        let mut data = build_png_header(100, 100);
+        // Overwrite "IHDR" with "tEXt"
+        data[12] = b't';
+        data[13] = b'E';
+        data[14] = b'X';
+        data[15] = b't';
+        let result = read_png_dimensions(&data);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not IHDR"));
+    }
+
+    // ========================================================================
+    // JPEG テスト
+    // ========================================================================
+
+    #[test]
+    fn reads_jpeg_sof0_baseline() {
+        let data = build_jpeg_with_sof(1920, 1080, 0xC0, &[]);
+        let dim = read_jpeg_dimensions(&data).unwrap();
+        assert_eq!(
+            dim,
+            ImageDimensions {
+                width: 1920,
+                height: 1080
+            }
+        );
+    }
+
+    #[test]
+    fn reads_jpeg_sof2_progressive() {
+        let data = build_jpeg_with_sof(1280, 720, 0xC2, &[]);
+        let dim = read_jpeg_dimensions(&data).unwrap();
+        assert_eq!(
+            dim,
+            ImageDimensions {
+                width: 1280,
+                height: 720
+            }
+        );
+    }
+
+    #[test]
+    fn reads_jpeg_sof_after_app0_and_app1() {
+        // APP0 (JFIF) + APP1 (EXIF placeholder) の後に SOF0
+        let app0_data = b"JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00";
+        let app1_data = vec![0u8; 1000]; // simulate 1KB EXIF data
+        let data = build_jpeg_with_sof(
+            3840,
+            2160,
+            0xC0,
+            &[(0xE0, app0_data), (0xE1, &app1_data)],
+        );
+        let dim = read_jpeg_dimensions(&data).unwrap();
+        assert_eq!(
+            dim,
+            ImageDimensions {
+                width: 3840,
+                height: 2160
+            }
+        );
+    }
+
+    #[test]
+    fn reads_jpeg_sof_after_large_app1() {
+        // 60KB の APP1 セグメント（大きな EXIF データをシミュレート）
+        let large_app1 = vec![0u8; 60000];
+        let data = build_jpeg_with_sof(2560, 1440, 0xC0, &[(0xE1, &large_app1)]);
+        let dim = read_jpeg_dimensions(&data).unwrap();
+        assert_eq!(
+            dim,
+            ImageDimensions {
+                width: 2560,
+                height: 1440
+            }
+        );
+    }
+
+    #[test]
+    fn handles_jpeg_padding_ff() {
+        // SOI の後に 0xFF パディングを挟む
+        let mut data = Vec::new();
+        data.extend_from_slice(&[0xFF, 0xD8]); // SOI
+        data.extend_from_slice(&[0xFF, 0xFF, 0xFF, 0xC0]); // padded SOF0
+        // SOF payload
+        let sof_length: u16 = 11;
+        data.extend_from_slice(&sof_length.to_be_bytes());
+        data.push(8); // precision
+        data.extend_from_slice(&720u16.to_be_bytes()); // height
+        data.extend_from_slice(&1280u16.to_be_bytes()); // width
+        data.push(1);
+        data.extend_from_slice(&[0, 0x11, 0]);
+        data.extend_from_slice(&[0xFF, 0xD9]); // EOI
+
+        let dim = read_jpeg_dimensions(&data).unwrap();
+        assert_eq!(
+            dim,
+            ImageDimensions {
+                width: 1280,
+                height: 720
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_jpeg_truncated() {
+        // SOI + APP0 marker but no SOF
+        let data = [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46];
+        let result = read_jpeg_dimensions(&data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_jpeg_wrong_soi() {
+        let data = [0x00, 0x00, 0xFF, 0xC0];
+        let result = read_jpeg_dimensions(&data);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("SOI"));
+    }
+
+    #[test]
+    fn rejects_jpeg_too_short() {
+        let result = read_jpeg_dimensions(&[0xFF]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("too short"));
+    }
+
+    // ========================================================================
+    // ファイルベーステスト
+    // ========================================================================
+
+    #[test]
+    fn returns_err_for_nonexistent_file() {
+        let result = read_image_dimensions_from_file("/nonexistent/path/image.png");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Failed to open"));
+    }
+
+    #[test]
+    fn returns_err_for_unknown_format() {
+        // 一時ファイルにランダムデータを書き込む
+        let dir = std::env::temp_dir();
+        let path = dir.join("test_unknown_format.dat");
+        let mut f = File::create(&path).unwrap();
+        f.write_all(&[0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08])
+            .unwrap();
+        drop(f);
+
+        let result = read_image_dimensions_from_file(path.to_str().unwrap());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unknown image format"));
+
+        // クリーンアップ
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn reads_dimensions_from_png_file() {
+        let dir = std::env::temp_dir();
+        let path = dir.join("test_dim_1920x1080.png");
+        let header = build_png_header(1920, 1080);
+        // IHDR の残り（bit depth 以降）も書く必要がある
+        let mut full = header.clone();
+        // bit depth(1) + color type(1) + compression(1) + filter(1) + interlace(1) = 5 bytes
+        full.extend_from_slice(&[8, 2, 0, 0, 0]);
+        let mut f = File::create(&path).unwrap();
+        f.write_all(&full).unwrap();
+        drop(f);
+
+        let dim = read_image_dimensions_from_file(path.to_str().unwrap()).unwrap();
+        assert_eq!(
+            dim,
+            ImageDimensions {
+                width: 1920,
+                height: 1080
+            }
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn reads_dimensions_from_jpeg_file() {
+        let dir = std::env::temp_dir();
+        let path = dir.join("test_dim_1920x1080.jpeg");
+        let data = build_jpeg_with_sof(1920, 1080, 0xC0, &[]);
+        let mut f = File::create(&path).unwrap();
+        f.write_all(&data).unwrap();
+        drop(f);
+
+        let dim = read_image_dimensions_from_file(path.to_str().unwrap()).unwrap();
+        assert_eq!(
+            dim,
+            ImageDimensions {
+                width: 1920,
+                height: 1080
+            }
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/packages/exif-native/src/lib.rs
+++ b/packages/exif-native/src/lib.rs
@@ -7,6 +7,7 @@ extern crate napi_derive;
 
 mod container;
 mod detect;
+mod dimensions;
 mod exif;
 mod xmp;
 
@@ -15,6 +16,7 @@ use std::fs;
 
 use container::{jpeg, png};
 use detect::{detect_image_format, ImageFormat};
+use dimensions::read_image_dimensions_from_file;
 use exif::writer::{build_exif_bytes, ExifWriteParams};
 use xmp::reader::{parse_vrc_xmp, VrcXmpMetadata};
 
@@ -40,6 +42,13 @@ impl From<VrcXmpMetadata> for JsVrcXmpMetadata {
             world_display_name: m.world_display_name,
         }
     }
+}
+
+/// 画像サイズ（width/height）の読み取り結果
+#[napi(object)]
+pub struct JsImageDimensions {
+    pub width: u32,
+    pub height: u32,
 }
 
 /// EXIF 書き込み用パラメータ
@@ -154,6 +163,47 @@ pub fn detect_image_format_js(buffer: Buffer) -> String {
         ImageFormat::Png => "png".to_string(),
         ImageFormat::Unknown => "unknown".to_string(),
     }
+}
+
+// ============================================================================
+// 画像サイズ取得
+// ============================================================================
+
+/// ファイルパスから画像サイズ（width/height）を読み取る。
+///
+/// ファイルの先頭だけを部分読み込みするため、ファイル全体のデコードは不要。
+/// PNG: 先頭 24 バイト（IHDR チャンク）から取得。
+/// JPEG: 先頭 64KB をスキャンして SOF マーカーから取得。
+/// エラー時（ファイル未検出、権限エラー、不明フォーマット、破損ヘッダー）は null を返す。
+#[napi]
+pub fn read_image_dimensions(file_path: String) -> Option<JsImageDimensions> {
+    read_image_dimensions_from_file(&file_path)
+        .ok()
+        .map(|d| JsImageDimensions {
+            width: d.width,
+            height: d.height,
+        })
+}
+
+/// 複数ファイルから画像サイズをバッチ読み取り。
+///
+/// Rayon でスレッドプール並列化する。
+/// 個別のファイルでエラーが発生しても null を返し、他のファイルの処理を続行する。
+#[napi]
+pub fn read_image_dimensions_batch(file_paths: Vec<String>) -> Vec<Option<JsImageDimensions>> {
+    use rayon::prelude::*;
+
+    file_paths
+        .par_iter()
+        .map(|path| {
+            read_image_dimensions_from_file(path)
+                .ok()
+                .map(|d| JsImageDimensions {
+                    width: d.width,
+                    height: d.height,
+                })
+        })
+        .collect()
 }
 
 // ============================================================================

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,7 +303,11 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@22.15.35)(jsdom@27.4.0)(vite@8.0.3(@types/node@22.15.35)(esbuild@0.27.2)(jiti@2.6.1)(tsx@4.21.0))
 
-  packages/exif-native: {}
+  packages/exif-native:
+    devDependencies:
+      '@napi-rs/cli':
+        specifier: ^3.6.1
+        version: 3.6.1(@emnapi/runtime@1.8.1)(@types/node@22.15.35)(node-addon-api@7.1.1)
 
   pages:
     dependencies:
@@ -911,9 +915,143 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@inquirer/ansi@2.0.5':
+    resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/checkbox@5.1.3':
+    resolution: {integrity: sha512-+G7I8CT+EHv/hasNfUl3P37DVoMoZfpA+2FXmM54dA8MxYle1YqucxbacxHalw1iAFSdKNEDTGNV7F+j1Ldqcg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@6.0.11':
+    resolution: {integrity: sha512-pTpHjg0iEIRMYV/7oCZUMf27/383E6Wyhfc/MY+AVQGEoUobffIYWOK9YLP2XFRGz/9i6WlTQh1CkFVIo2Y7XA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.1.8':
+    resolution: {integrity: sha512-/u+yJk2pOKNDOh1ZgdUH2RQaRx6OOH4I0uwL95qPvTFTIL38YBsuSC4r1yXBB3Q6JvNqFFc202gk0Ew79rrcjA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@5.1.0':
+    resolution: {integrity: sha512-6wlkYl65Qfayy48gPCfU4D7li6KCAGN79mLXa/tYHZH99OfZ820yY+HA+DgE88r8YwwgeuY6PQgNqMeK6LuMmw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@5.0.12':
+    resolution: {integrity: sha512-vOfrB33b7YIZfDauXS8vNNz2Z86FozTZLIt7e+7/dCaPJ1RXZsHCuI9TlcERzEUq57vkM+UdnBgxP0rFd23JYQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/external-editor@1.0.3':
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@3.0.0':
+    resolution: {integrity: sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@2.0.5':
+    resolution: {integrity: sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/input@5.0.11':
+    resolution: {integrity: sha512-twUWidn4ocPO8qi6fRM7tNWt7W1FOnOZqQ+/+PsfLUacMR5rFLDPK9ql0nBPwxi0oELbo8T5NhRs8B2+qQEqFQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@4.0.11':
+    resolution: {integrity: sha512-Vscmim9TCksQsfjPtka/JwPUcbLhqWYrgfPf1cHrCm24X/F2joFwnageD50yMKsaX14oNGOyKf/RNXAFkNjWpA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@5.0.11':
+    resolution: {integrity: sha512-9KZFeRaNHIcejtPb0wN4ddFc7EvobVoAFa049eS3LrDZFxI8O7xUXiITEOinBzkZFAIwY5V4yzQae/QfO9cbbg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@8.4.1':
+    resolution: {integrity: sha512-AH5xPQ997K7e0F0vulPlteIHke2awMkFi8F0dBemrDfmvtPmHJo82mdHbONC4F/t8d1NHwrbI5cGVI+RbLWdoQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@5.2.7':
+    resolution: {integrity: sha512-AqRMiD9+uE1lskDPrdqHwrV/EUmxKEBLX44SR7uxK3vD2413AmVfE5EQaPeNzYf5Pq5SitHJDYUFVF0poIr09w==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@4.1.7':
+    resolution: {integrity: sha512-1y7+0N65AWk5RdlXH/Kn13txf3IjIQ7OEfhCEkDTU+h5wKMLq8DUF3P6z+/kLSxDGDtQT1dRBWEUC3o/VvImsQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@5.1.3':
+    resolution: {integrity: sha512-zYyqWgGQi3NhBcNq4Isc5rB3oEdQEh1Q/EcAnOW0FK4MpnXWkvSBYgA4cYrTM4A9UB573omouZbnL9JJ74Mq3A==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@4.0.5':
+    resolution: {integrity: sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -957,6 +1095,51 @@ packages:
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@napi-rs/cli@3.6.1':
+    resolution: {integrity: sha512-xOrDmCdtXfJ2XzknJAyEAMUe4SHT02PHY3JG8/vXFAB+EPF7Pgv0q182Vmw2zAlhAvnfofccvJlHrZpNPDbypA==}
+    engines: {node: '>= 16'}
+    hasBin: true
+    peerDependencies:
+      '@emnapi/runtime': ^1.7.1
+    peerDependenciesMeta:
+      '@emnapi/runtime':
+        optional: true
+
+  '@napi-rs/cross-toolchain@1.0.3':
+    resolution: {integrity: sha512-ENPfLe4937bsKVTDA6zdABx4pq9w0tHqRrJHyaGxgaPq03a2Bd1unD5XSKjXJjebsABJ+MjAv1A2OvCgK9yehg==}
+    peerDependencies:
+      '@napi-rs/cross-toolchain-arm64-target-aarch64': ^1.0.3
+      '@napi-rs/cross-toolchain-arm64-target-armv7': ^1.0.3
+      '@napi-rs/cross-toolchain-arm64-target-ppc64le': ^1.0.3
+      '@napi-rs/cross-toolchain-arm64-target-s390x': ^1.0.3
+      '@napi-rs/cross-toolchain-arm64-target-x86_64': ^1.0.3
+      '@napi-rs/cross-toolchain-x64-target-aarch64': ^1.0.3
+      '@napi-rs/cross-toolchain-x64-target-armv7': ^1.0.3
+      '@napi-rs/cross-toolchain-x64-target-ppc64le': ^1.0.3
+      '@napi-rs/cross-toolchain-x64-target-s390x': ^1.0.3
+      '@napi-rs/cross-toolchain-x64-target-x86_64': ^1.0.3
+    peerDependenciesMeta:
+      '@napi-rs/cross-toolchain-arm64-target-aarch64':
+        optional: true
+      '@napi-rs/cross-toolchain-arm64-target-armv7':
+        optional: true
+      '@napi-rs/cross-toolchain-arm64-target-ppc64le':
+        optional: true
+      '@napi-rs/cross-toolchain-arm64-target-s390x':
+        optional: true
+      '@napi-rs/cross-toolchain-arm64-target-x86_64':
+        optional: true
+      '@napi-rs/cross-toolchain-x64-target-aarch64':
+        optional: true
+      '@napi-rs/cross-toolchain-x64-target-armv7':
+        optional: true
+      '@napi-rs/cross-toolchain-x64-target-ppc64le':
+        optional: true
+      '@napi-rs/cross-toolchain-x64-target-s390x':
+        optional: true
+      '@napi-rs/cross-toolchain-x64-target-x86_64':
+        optional: true
 
   '@napi-rs/image-android-arm64@1.12.0':
     resolution: {integrity: sha512-MAm8EHmtO47OZYsHgiMuP+nYZOEbNWbHjkoNfRS9wFJiRQ5p/pIlvdeWL9DqkSrjcgHjIJXLcrt94MMF1jXOuw==}
@@ -1039,8 +1222,293 @@ packages:
     resolution: {integrity: sha512-hfW9EvlUj4R+RYu5Cgcm9/d/2eMTj3Dhypj0BD+snasawBpYwSfkPZx/6C1Hm2cVCbRT6zovGdSHUXwPLb29dw==}
     engines: {node: '>= 10'}
 
+  '@napi-rs/lzma-android-arm-eabi@1.4.5':
+    resolution: {integrity: sha512-Up4gpyw2SacmyKWWEib06GhiDdF+H+CCU0LAV8pnM4aJIDqKKd5LHSlBht83Jut6frkB0vwEPmAkv4NjQ5u//Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@napi-rs/lzma-android-arm64@1.4.5':
+    resolution: {integrity: sha512-uwa8sLlWEzkAM0MWyoZJg0JTD3BkPknvejAFG2acUA1raXM8jLrqujWCdOStisXhqQjZ2nDMp3FV6cs//zjfuQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/lzma-darwin-arm64@1.4.5':
+    resolution: {integrity: sha512-0Y0TQLQ2xAjVabrMDem1NhIssOZzF/y/dqetc6OT8mD3xMTDtF8u5BqZoX3MyPc9FzpsZw4ksol+w7DsxHrpMA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/lzma-darwin-x64@1.4.5':
+    resolution: {integrity: sha512-vR2IUyJY3En+V1wJkwmbGWcYiT8pHloTAWdW4pG24+51GIq+intst6Uf6D/r46citObGZrlX0QvMarOkQeHWpw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/lzma-freebsd-x64@1.4.5':
+    resolution: {integrity: sha512-XpnYQC5SVovO35tF0xGkbHYjsS6kqyNCjuaLQ2dbEblFRr5cAZVvsJ/9h7zj/5FluJPJRDojVNxGyRhTp4z2lw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@napi-rs/lzma-linux-arm-gnueabihf@1.4.5':
+    resolution: {integrity: sha512-ic1ZZMoRfRMwtSwxkyw4zIlbDZGC6davC9r+2oX6x9QiF247BRqqT94qGeL5ZP4Vtz0Hyy7TEViWhx5j6Bpzvw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/lzma-linux-arm64-gnu@1.4.5':
+    resolution: {integrity: sha512-asEp7FPd7C1Yi6DQb45a3KPHKOFBSfGuJWXcAd4/bL2Fjetb2n/KK2z14yfW8YC/Fv6x3rBM0VAZKmJuz4tysg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/lzma-linux-arm64-musl@1.4.5':
+    resolution: {integrity: sha512-yWjcPDgJ2nIL3KNvi4536dlT/CcCWO0DUyEOlBs/SacG7BeD6IjGh6yYzd3/X1Y3JItCbZoDoLUH8iB1lTXo3w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/lzma-linux-ppc64-gnu@1.4.5':
+    resolution: {integrity: sha512-0XRhKuIU/9ZjT4WDIG/qnX7Xz7mSQHYZo9Gb3MP2gcvBgr6BA4zywQ9k3gmQaPn9ECE+CZg2V7DV7kT+x2pUMQ==}
+    engines: {node: '>= 10'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@napi-rs/lzma-linux-riscv64-gnu@1.4.5':
+    resolution: {integrity: sha512-QrqDIPEUUB23GCpyQj/QFyMlr8SGxxyExeZz9OWFnHfb70kXdTLWrHS/hEI1Ru+lSbQ/6xRqeoGyQ4Aqdg+/RA==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@napi-rs/lzma-linux-s390x-gnu@1.4.5':
+    resolution: {integrity: sha512-k8RVM5aMhW86E9H0QXdquwojew4H3SwPxbRVbl49/COJQWCUjGi79X6mYruMnMPEznZinUiT1jgKbFo2A00NdA==}
+    engines: {node: '>= 10'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@napi-rs/lzma-linux-x64-gnu@1.4.5':
+    resolution: {integrity: sha512-6rMtBgnIq2Wcl1rQdZsnM+rtCcVCbws1nF8S2NzaUsVaZv8bjrPiAa0lwg4Eqnn1d9lgwqT+cZgm5m+//K08Kw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/lzma-linux-x64-musl@1.4.5':
+    resolution: {integrity: sha512-eiadGBKi7Vd0bCArBUOO/qqRYPHt/VQVvGyYvDFt6C2ZSIjlD+HuOl+2oS1sjf4CFjK4eDIog6EdXnL0NE6iyQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/lzma-wasm32-wasi@1.4.5':
+    resolution: {integrity: sha512-+VyHHlr68dvey6fXc2hehw9gHVFIW3TtGF1XkcbAu65qVXsA9D/T+uuoRVqhE+JCyFHFrO0ixRbZDRK1XJt1sA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@napi-rs/lzma-win32-arm64-msvc@1.4.5':
+    resolution: {integrity: sha512-eewnqvIyyhHi3KaZtBOJXohLvwwN27gfS2G/YDWdfHlbz1jrmfeHAmzMsP5qv8vGB+T80TMHNkro4kYjeh6Deg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/lzma-win32-ia32-msvc@1.4.5':
+    resolution: {integrity: sha512-OeacFVRCJOKNU/a0ephUfYZ2Yt+NvaHze/4TgOwJ0J0P4P7X1mHzN+ig9Iyd74aQDXYqc7kaCXA2dpAOcH87Cg==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@napi-rs/lzma-win32-x64-msvc@1.4.5':
+    resolution: {integrity: sha512-T4I1SamdSmtyZgDXGAGP+y5LEK5vxHUFwe8mz6D4R7Sa5/WCxTcCIgPJ9BD7RkpO17lzhlaM2vmVvMy96Lvk9Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/lzma@1.4.5':
+    resolution: {integrity: sha512-zS5LuN1OBPAyZpda2ZZgYOEDC+xecUdAGnrvbYzjnLXkrq/OBC3B9qcRvlxbDR3k5H/gVfvef1/jyUqPknqjbg==}
+    engines: {node: '>= 10'}
+
+  '@napi-rs/tar-android-arm-eabi@1.1.0':
+    resolution: {integrity: sha512-h2Ryndraj/YiKgMV/r5by1cDusluYIRT0CaE0/PekQ4u+Wpy2iUVqvzVU98ZPnhXaNeYxEvVJHNGafpOfaD0TA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@napi-rs/tar-android-arm64@1.1.0':
+    resolution: {integrity: sha512-DJFyQHr1ZxNZorm/gzc1qBNLF/FcKzcH0V0Vwan5P+o0aE2keQIGEjJ09FudkF9v6uOuJjHCVDdK6S6uHtShAw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/tar-darwin-arm64@1.1.0':
+    resolution: {integrity: sha512-Zz2sXRzjIX4e532zD6xm2SjXEym6MkvfCvL2RMpG2+UwNVDVscHNcz3d47Pf3sysP2e2af7fBB3TIoK2f6trPw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/tar-darwin-x64@1.1.0':
+    resolution: {integrity: sha512-EI+CptIMNweT0ms9S3mkP/q+J6FNZ1Q6pvpJOEcWglRfyfQpLqjlC0O+dptruTPE8VamKYuqdjxfqD8hifZDOA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/tar-freebsd-x64@1.1.0':
+    resolution: {integrity: sha512-J0PIqX+pl6lBIAckL/c87gpodLbjZB1OtIK+RDscKC9NLdpVv6VGOxzUV/fYev/hctcE8EfkLbgFOfpmVQPg2g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@napi-rs/tar-linux-arm-gnueabihf@1.1.0':
+    resolution: {integrity: sha512-SLgIQo3f3EjkZ82ZwvrEgFvMdDAhsxCYjyoSuWfHCz0U16qx3SuGCp8+FYOPYCECHN3ZlGjXnoAIt9ERd0dEUg==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/tar-linux-arm64-gnu@1.1.0':
+    resolution: {integrity: sha512-d014cdle52EGaH6GpYTQOP9Py7glMO1zz/+ynJPjjzYFSxvdYx0byrjumZk2UQdIyGZiJO2MEFpCkEEKFSgPYA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/tar-linux-arm64-musl@1.1.0':
+    resolution: {integrity: sha512-L/y1/26q9L/uBqiW/JdOb/Dc94egFvNALUZV2WCGKQXc6UByPBMgdiEyW2dtoYxYYYYc+AKD+jr+wQPcvX2vrQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/tar-linux-ppc64-gnu@1.1.0':
+    resolution: {integrity: sha512-EPE1K/80RQvPbLRJDJs1QmCIcH+7WRi0F73+oTe1582y9RtfGRuzAkzeBuAGRXAQEjRQw/RjtNqr6UTJ+8UuWQ==}
+    engines: {node: '>= 10'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@napi-rs/tar-linux-s390x-gnu@1.1.0':
+    resolution: {integrity: sha512-B2jhWiB1ffw1nQBqLUP1h4+J1ovAxBOoe5N2IqDMOc63fsPZKNqF1PvO/dIem8z7LL4U4bsfmhy3gBfu547oNQ==}
+    engines: {node: '>= 10'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@napi-rs/tar-linux-x64-gnu@1.1.0':
+    resolution: {integrity: sha512-tbZDHnb9617lTnsDMGo/eAMZxnsQFnaRe+MszRqHguKfMwkisc9CCJnks/r1o84u5fECI+J/HOrKXgczq/3Oww==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/tar-linux-x64-musl@1.1.0':
+    resolution: {integrity: sha512-dV6cODlzbO8u6Anmv2N/ilQHq/AWz0xyltuXoLU3yUyXbZcnWYZuB2rL8OBGPmqNcD+x9NdScBNXh7vWN0naSQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/tar-wasm32-wasi@1.1.0':
+    resolution: {integrity: sha512-jIa9nb2HzOrfH0F8QQ9g3WE4aMH5vSI5/1NYVNm9ysCmNjCCtMXCAhlI3WKCdm/DwHf0zLqdrrtDFXODcNaqMw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@napi-rs/tar-win32-arm64-msvc@1.1.0':
+    resolution: {integrity: sha512-vfpG71OB0ijtjemp3WTdmBKJm9R70KM8vsSExMsIQtV0lVzP07oM1CW6JbNRPXNLhRoue9ofYLiUDk8bE0Hckg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/tar-win32-ia32-msvc@1.1.0':
+    resolution: {integrity: sha512-hGPyPW60YSpOSgzfy68DLBHgi6HxkAM+L59ZZZPMQ0TOXjQg+p2EW87+TjZfJOkSpbYiEkULwa/f4a2hcVjsqQ==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@napi-rs/tar-win32-x64-msvc@1.1.0':
+    resolution: {integrity: sha512-L6Ed1DxXK9YSCMyvpR8MiNAyKNkQLjsHsHK9E0qnHa8NzLFqzDKhvs5LfnWxM2kJ+F7m/e5n9zPm24kHb3LsVw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/tar@1.1.0':
+    resolution: {integrity: sha512-7cmzIu+Vbupriudo7UudoMRH2OA3cTw67vva8MxeoAe5S7vPFI7z0vp0pMXiA25S8IUJefImQ90FeJjl8fjEaQ==}
+    engines: {node: '>= 10'}
+
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+
+  '@napi-rs/wasm-tools-android-arm-eabi@1.0.1':
+    resolution: {integrity: sha512-lr07E/l571Gft5v4aA1dI8koJEmF1F0UigBbsqg9OWNzg80H3lDPO+auv85y3T/NHE3GirDk7x/D3sLO57vayw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@napi-rs/wasm-tools-android-arm64@1.0.1':
+    resolution: {integrity: sha512-WDR7S+aRLV6LtBJAg5fmjKkTZIdrEnnQxgdsb7Cf8pYiMWBHLU+LC49OUVppQ2YSPY0+GeYm9yuZWW3kLjJ7Bg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/wasm-tools-darwin-arm64@1.0.1':
+    resolution: {integrity: sha512-qWTI+EEkiN0oIn/N2gQo7+TVYil+AJ20jjuzD2vATS6uIjVz+Updeqmszi7zq7rdFTLp6Ea3/z4kDKIfZwmR9g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/wasm-tools-darwin-x64@1.0.1':
+    resolution: {integrity: sha512-bA6hubqtHROR5UI3tToAF/c6TDmaAgF0SWgo4rADHtQ4wdn0JeogvOk50gs2TYVhKPE2ZD2+qqt7oBKB+sxW3A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/wasm-tools-freebsd-x64@1.0.1':
+    resolution: {integrity: sha512-90+KLBkD9hZEjPQW1MDfwSt5J1L46EUKacpCZWyRuL6iIEO5CgWU0V/JnEgFsDOGyyYtiTvHc5bUdUTWd4I9Vg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@napi-rs/wasm-tools-linux-arm64-gnu@1.0.1':
+    resolution: {integrity: sha512-rG0QlS65x9K/u3HrKafDf8cFKj5wV2JHGfl8abWgKew0GVPyp6vfsDweOwHbWAjcHtp2LHi6JHoW80/MTHm52Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/wasm-tools-linux-arm64-musl@1.0.1':
+    resolution: {integrity: sha512-jAasbIvjZXCgX0TCuEFQr+4D6Lla/3AAVx2LmDuMjgG4xoIXzjKWl7c4chuaD+TI+prWT0X6LJcdzFT+ROKGHQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/wasm-tools-linux-x64-gnu@1.0.1':
+    resolution: {integrity: sha512-Plgk5rPqqK2nocBGajkMVbGm010Z7dnUgq0wtnYRZbzWWxwWcXfZMPa8EYxrK4eE8SzpI7VlZP1tdVsdjgGwMw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/wasm-tools-linux-x64-musl@1.0.1':
+    resolution: {integrity: sha512-GW7AzGuWxtQkyHknHWYFdR0CHmW6is8rG2Rf4V6GNmMpmwtXt/ItWYWtBe4zqJWycMNazpfZKSw/BpT7/MVCXQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/wasm-tools-wasm32-wasi@1.0.1':
+    resolution: {integrity: sha512-/nQVSTrqSsn7YdAc2R7Ips/tnw5SPUcl3D7QrXCNGPqjbatIspnaexvaOYNyKMU6xPu+pc0BTnKVmqhlJJCPLA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@napi-rs/wasm-tools-win32-arm64-msvc@1.0.1':
+    resolution: {integrity: sha512-PFi7oJIBu5w7Qzh3dwFea3sHRO3pojMsaEnUIy22QvsW+UJfNQwJCryVrpoUt8m4QyZXI+saEq/0r4GwdoHYFQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/wasm-tools-win32-ia32-msvc@1.0.1':
+    resolution: {integrity: sha512-gXkuYzxQsgkj05Zaq+KQTkHIN83dFAwMcTKa2aQcpYPRImFm2AQzEyLtpXmyCWzJ0F9ZYAOmbSyrNew8/us6bw==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@napi-rs/wasm-tools-win32-x64-msvc@1.0.1':
+    resolution: {integrity: sha512-rEAf05nol3e3eei2sRButmgXP+6ATgm0/38MKhz9Isne82T4rPIMYsCIFj0kOisaGeVwoi2fnm7O9oWp5YVnYQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/wasm-tools@1.0.1':
+    resolution: {integrity: sha512-enkZYyuCdo+9jneCPE/0fjIta4wWnvVN9hBo2HuiMpRF0q3lzv1J6b/cl7i0mxZUKhBrV3aCKDBQnCOhwKbPmQ==}
+    engines: {node: '>= 10'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1069,6 +1537,58 @@ packages:
     resolution: {integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==}
     engines: {node: '>=10'}
     deprecated: This functionality has been moved to @npmcli/fs
+
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/core@7.0.6':
+    resolution: {integrity: sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==}
+    engines: {node: '>= 20'}
+
+  '@octokit/endpoint@11.0.3':
+    resolution: {integrity: sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==}
+    engines: {node: '>= 20'}
+
+  '@octokit/graphql@9.0.3':
+    resolution: {integrity: sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
+
+  '@octokit/plugin-paginate-rest@14.0.0':
+    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-request-log@6.0.0':
+    resolution: {integrity: sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0':
+    resolution: {integrity: sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/request-error@7.1.0':
+    resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.8':
+    resolution: {integrity: sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/rest@22.0.1':
+    resolution: {integrity: sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
   '@opentelemetry/api-logs@0.208.0':
     resolution: {integrity: sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==}
@@ -3163,6 +3683,9 @@ packages:
     resolution: {integrity: sha512-+T7Ho09ikx/kP4P8M+GEnpuePzRQa4gTUhtPIu6ApFC8+0GY0sri1y1PuB+yfXlQWl5DkHC/e58z3U6g0qCz/A==}
     engines: {node: '>=20'}
 
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -3331,6 +3854,10 @@ packages:
     resolution: {integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==}
     engines: {node: '>=8'}
 
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
   clip-filepaths-darwin-arm64@0.3.0:
     resolution: {integrity: sha512-MNsead3rwMUg/i2+Qn4XUK/O2wPmR+viMwAB2ogd10YdKgAjNqRnVYYMSw3ZAbHy+mIg2xK/sQXsTefwXXMHng==}
     engines: {node: '>= 20'}
@@ -3383,6 +3910,11 @@ packages:
     resolution: {integrity: sha512-RTvOf16co5+Xqpn9ioDKDHYG2Ie7qhL0CSHstrC2u1hCHpb5QxUOnti4rO8hF+uwqonr/KriO6PfXf1zLSGBqA==}
     engines: {node: '>= 20'}
 
+  clipanion@4.0.0-rc.4:
+    resolution: {integrity: sha512-CXkMQxU6s9GklO/1f714dkKBMu1lopS1WFF0B8o4AxPykR1hpozxSiUZ5ZUeBjfPgCWqbcNOtZVFhB8Lkfp1+Q==}
+    peerDependencies:
+      typanion: '*'
+
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
@@ -3414,6 +3946,9 @@ packages:
   color-support@1.1.3:
     resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
     hasBin: true
+
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -3620,6 +4155,7 @@ packages:
 
   dottie@2.0.7:
     resolution: {integrity: sha512-7lAK2A0b3zZr3UC5aE69CPdCFR4RHW1o2Dr74TqFykxkUCBXSRJum/yPc7g8zRHJqWKomPLHwFLLoUnn8PXXRg==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -3675,6 +4211,14 @@ packages:
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
+  emnapi@1.9.2:
+    resolution: {integrity: sha512-OdUoQe/8so7FvubnE/DNV9sNNSFwDYQiK4ZCAz4agMnD1s6faLuDn2gzxfJrmMoKfxZhhsckqGNwqPnS5K140A==}
+    peerDependencies:
+      node-addon-api: '>= 6.1.0'
+    peerDependenciesMeta:
+      node-addon-api:
+        optional: true
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -3728,6 +4272,9 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.45.1:
+    resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
 
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
@@ -3863,6 +4410,9 @@ packages:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
 
+  fast-content-type-parse@3.0.0:
+    resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -3876,8 +4426,17 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-wrap-ansi@0.2.0:
+    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -4415,6 +4974,9 @@ packages:
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
+  json-with-bigint@3.5.8:
+    resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -4876,6 +5438,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -5878,6 +6444,9 @@ packages:
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
+  typanion@3.14.0:
+    resolution: {integrity: sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -5956,6 +6525,9 @@ packages:
 
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -6960,10 +7532,129 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@inquirer/ansi@2.0.5': {}
+
+  '@inquirer/checkbox@5.1.3(@types/node@22.15.35)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/core': 11.1.8(@types/node@22.15.35)
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@22.15.35)
+    optionalDependencies:
+      '@types/node': 22.15.35
+
+  '@inquirer/confirm@6.0.11(@types/node@22.15.35)':
+    dependencies:
+      '@inquirer/core': 11.1.8(@types/node@22.15.35)
+      '@inquirer/type': 4.0.5(@types/node@22.15.35)
+    optionalDependencies:
+      '@types/node': 22.15.35
+
+  '@inquirer/core@11.1.8(@types/node@22.15.35)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@22.15.35)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.0
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 22.15.35
+
+  '@inquirer/editor@5.1.0(@types/node@22.15.35)':
+    dependencies:
+      '@inquirer/core': 11.1.8(@types/node@22.15.35)
+      '@inquirer/external-editor': 3.0.0(@types/node@22.15.35)
+      '@inquirer/type': 4.0.5(@types/node@22.15.35)
+    optionalDependencies:
+      '@types/node': 22.15.35
+
+  '@inquirer/expand@5.0.12(@types/node@22.15.35)':
+    dependencies:
+      '@inquirer/core': 11.1.8(@types/node@22.15.35)
+      '@inquirer/type': 4.0.5(@types/node@22.15.35)
+    optionalDependencies:
+      '@types/node': 22.15.35
+
   '@inquirer/external-editor@1.0.3(@types/node@22.15.35)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 22.15.35
+
+  '@inquirer/external-editor@3.0.0(@types/node@22.15.35)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 22.15.35
+
+  '@inquirer/figures@2.0.5': {}
+
+  '@inquirer/input@5.0.11(@types/node@22.15.35)':
+    dependencies:
+      '@inquirer/core': 11.1.8(@types/node@22.15.35)
+      '@inquirer/type': 4.0.5(@types/node@22.15.35)
+    optionalDependencies:
+      '@types/node': 22.15.35
+
+  '@inquirer/number@4.0.11(@types/node@22.15.35)':
+    dependencies:
+      '@inquirer/core': 11.1.8(@types/node@22.15.35)
+      '@inquirer/type': 4.0.5(@types/node@22.15.35)
+    optionalDependencies:
+      '@types/node': 22.15.35
+
+  '@inquirer/password@5.0.11(@types/node@22.15.35)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/core': 11.1.8(@types/node@22.15.35)
+      '@inquirer/type': 4.0.5(@types/node@22.15.35)
+    optionalDependencies:
+      '@types/node': 22.15.35
+
+  '@inquirer/prompts@8.4.1(@types/node@22.15.35)':
+    dependencies:
+      '@inquirer/checkbox': 5.1.3(@types/node@22.15.35)
+      '@inquirer/confirm': 6.0.11(@types/node@22.15.35)
+      '@inquirer/editor': 5.1.0(@types/node@22.15.35)
+      '@inquirer/expand': 5.0.12(@types/node@22.15.35)
+      '@inquirer/input': 5.0.11(@types/node@22.15.35)
+      '@inquirer/number': 4.0.11(@types/node@22.15.35)
+      '@inquirer/password': 5.0.11(@types/node@22.15.35)
+      '@inquirer/rawlist': 5.2.7(@types/node@22.15.35)
+      '@inquirer/search': 4.1.7(@types/node@22.15.35)
+      '@inquirer/select': 5.1.3(@types/node@22.15.35)
+    optionalDependencies:
+      '@types/node': 22.15.35
+
+  '@inquirer/rawlist@5.2.7(@types/node@22.15.35)':
+    dependencies:
+      '@inquirer/core': 11.1.8(@types/node@22.15.35)
+      '@inquirer/type': 4.0.5(@types/node@22.15.35)
+    optionalDependencies:
+      '@types/node': 22.15.35
+
+  '@inquirer/search@4.1.7(@types/node@22.15.35)':
+    dependencies:
+      '@inquirer/core': 11.1.8(@types/node@22.15.35)
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@22.15.35)
+    optionalDependencies:
+      '@types/node': 22.15.35
+
+  '@inquirer/select@5.1.3(@types/node@22.15.35)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/core': 11.1.8(@types/node@22.15.35)
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@22.15.35)
+    optionalDependencies:
+      '@types/node': 22.15.35
+
+  '@inquirer/type@4.0.5(@types/node@22.15.35)':
     optionalDependencies:
       '@types/node': 22.15.35
 
@@ -7028,6 +7719,45 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
+  '@napi-rs/cli@3.6.1(@emnapi/runtime@1.8.1)(@types/node@22.15.35)(node-addon-api@7.1.1)':
+    dependencies:
+      '@inquirer/prompts': 8.4.1(@types/node@22.15.35)
+      '@napi-rs/cross-toolchain': 1.0.3
+      '@napi-rs/wasm-tools': 1.0.1
+      '@octokit/rest': 22.0.1
+      clipanion: 4.0.0-rc.4(typanion@3.14.0)
+      colorette: 2.0.20
+      emnapi: 1.9.2(node-addon-api@7.1.1)
+      es-toolkit: 1.45.1
+      js-yaml: 4.1.1
+      obug: 2.1.1
+      semver: 7.7.3
+      typanion: 3.14.0
+    optionalDependencies:
+      '@emnapi/runtime': 1.8.1
+    transitivePeerDependencies:
+      - '@napi-rs/cross-toolchain-arm64-target-aarch64'
+      - '@napi-rs/cross-toolchain-arm64-target-armv7'
+      - '@napi-rs/cross-toolchain-arm64-target-ppc64le'
+      - '@napi-rs/cross-toolchain-arm64-target-s390x'
+      - '@napi-rs/cross-toolchain-arm64-target-x86_64'
+      - '@napi-rs/cross-toolchain-x64-target-aarch64'
+      - '@napi-rs/cross-toolchain-x64-target-armv7'
+      - '@napi-rs/cross-toolchain-x64-target-ppc64le'
+      - '@napi-rs/cross-toolchain-x64-target-s390x'
+      - '@napi-rs/cross-toolchain-x64-target-x86_64'
+      - '@types/node'
+      - node-addon-api
+      - supports-color
+
+  '@napi-rs/cross-toolchain@1.0.3':
+    dependencies:
+      '@napi-rs/lzma': 1.4.5
+      '@napi-rs/tar': 1.1.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@napi-rs/image-android-arm64@1.12.0':
     optional: true
 
@@ -7085,12 +7815,211 @@ snapshots:
       '@napi-rs/image-win32-ia32-msvc': 1.12.0
       '@napi-rs/image-win32-x64-msvc': 1.12.0
 
+  '@napi-rs/lzma-android-arm-eabi@1.4.5':
+    optional: true
+
+  '@napi-rs/lzma-android-arm64@1.4.5':
+    optional: true
+
+  '@napi-rs/lzma-darwin-arm64@1.4.5':
+    optional: true
+
+  '@napi-rs/lzma-darwin-x64@1.4.5':
+    optional: true
+
+  '@napi-rs/lzma-freebsd-x64@1.4.5':
+    optional: true
+
+  '@napi-rs/lzma-linux-arm-gnueabihf@1.4.5':
+    optional: true
+
+  '@napi-rs/lzma-linux-arm64-gnu@1.4.5':
+    optional: true
+
+  '@napi-rs/lzma-linux-arm64-musl@1.4.5':
+    optional: true
+
+  '@napi-rs/lzma-linux-ppc64-gnu@1.4.5':
+    optional: true
+
+  '@napi-rs/lzma-linux-riscv64-gnu@1.4.5':
+    optional: true
+
+  '@napi-rs/lzma-linux-s390x-gnu@1.4.5':
+    optional: true
+
+  '@napi-rs/lzma-linux-x64-gnu@1.4.5':
+    optional: true
+
+  '@napi-rs/lzma-linux-x64-musl@1.4.5':
+    optional: true
+
+  '@napi-rs/lzma-wasm32-wasi@1.4.5':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
+    optional: true
+
+  '@napi-rs/lzma-win32-arm64-msvc@1.4.5':
+    optional: true
+
+  '@napi-rs/lzma-win32-ia32-msvc@1.4.5':
+    optional: true
+
+  '@napi-rs/lzma-win32-x64-msvc@1.4.5':
+    optional: true
+
+  '@napi-rs/lzma@1.4.5':
+    optionalDependencies:
+      '@napi-rs/lzma-android-arm-eabi': 1.4.5
+      '@napi-rs/lzma-android-arm64': 1.4.5
+      '@napi-rs/lzma-darwin-arm64': 1.4.5
+      '@napi-rs/lzma-darwin-x64': 1.4.5
+      '@napi-rs/lzma-freebsd-x64': 1.4.5
+      '@napi-rs/lzma-linux-arm-gnueabihf': 1.4.5
+      '@napi-rs/lzma-linux-arm64-gnu': 1.4.5
+      '@napi-rs/lzma-linux-arm64-musl': 1.4.5
+      '@napi-rs/lzma-linux-ppc64-gnu': 1.4.5
+      '@napi-rs/lzma-linux-riscv64-gnu': 1.4.5
+      '@napi-rs/lzma-linux-s390x-gnu': 1.4.5
+      '@napi-rs/lzma-linux-x64-gnu': 1.4.5
+      '@napi-rs/lzma-linux-x64-musl': 1.4.5
+      '@napi-rs/lzma-wasm32-wasi': 1.4.5
+      '@napi-rs/lzma-win32-arm64-msvc': 1.4.5
+      '@napi-rs/lzma-win32-ia32-msvc': 1.4.5
+      '@napi-rs/lzma-win32-x64-msvc': 1.4.5
+
+  '@napi-rs/tar-android-arm-eabi@1.1.0':
+    optional: true
+
+  '@napi-rs/tar-android-arm64@1.1.0':
+    optional: true
+
+  '@napi-rs/tar-darwin-arm64@1.1.0':
+    optional: true
+
+  '@napi-rs/tar-darwin-x64@1.1.0':
+    optional: true
+
+  '@napi-rs/tar-freebsd-x64@1.1.0':
+    optional: true
+
+  '@napi-rs/tar-linux-arm-gnueabihf@1.1.0':
+    optional: true
+
+  '@napi-rs/tar-linux-arm64-gnu@1.1.0':
+    optional: true
+
+  '@napi-rs/tar-linux-arm64-musl@1.1.0':
+    optional: true
+
+  '@napi-rs/tar-linux-ppc64-gnu@1.1.0':
+    optional: true
+
+  '@napi-rs/tar-linux-s390x-gnu@1.1.0':
+    optional: true
+
+  '@napi-rs/tar-linux-x64-gnu@1.1.0':
+    optional: true
+
+  '@napi-rs/tar-linux-x64-musl@1.1.0':
+    optional: true
+
+  '@napi-rs/tar-wasm32-wasi@1.1.0':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
+    optional: true
+
+  '@napi-rs/tar-win32-arm64-msvc@1.1.0':
+    optional: true
+
+  '@napi-rs/tar-win32-ia32-msvc@1.1.0':
+    optional: true
+
+  '@napi-rs/tar-win32-x64-msvc@1.1.0':
+    optional: true
+
+  '@napi-rs/tar@1.1.0':
+    optionalDependencies:
+      '@napi-rs/tar-android-arm-eabi': 1.1.0
+      '@napi-rs/tar-android-arm64': 1.1.0
+      '@napi-rs/tar-darwin-arm64': 1.1.0
+      '@napi-rs/tar-darwin-x64': 1.1.0
+      '@napi-rs/tar-freebsd-x64': 1.1.0
+      '@napi-rs/tar-linux-arm-gnueabihf': 1.1.0
+      '@napi-rs/tar-linux-arm64-gnu': 1.1.0
+      '@napi-rs/tar-linux-arm64-musl': 1.1.0
+      '@napi-rs/tar-linux-ppc64-gnu': 1.1.0
+      '@napi-rs/tar-linux-s390x-gnu': 1.1.0
+      '@napi-rs/tar-linux-x64-gnu': 1.1.0
+      '@napi-rs/tar-linux-x64-musl': 1.1.0
+      '@napi-rs/tar-wasm32-wasi': 1.1.0
+      '@napi-rs/tar-win32-arm64-msvc': 1.1.0
+      '@napi-rs/tar-win32-ia32-msvc': 1.1.0
+      '@napi-rs/tar-win32-x64-msvc': 1.1.0
+
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
       '@emnapi/core': 1.8.1
       '@emnapi/runtime': 1.8.1
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@napi-rs/wasm-tools-android-arm-eabi@1.0.1':
+    optional: true
+
+  '@napi-rs/wasm-tools-android-arm64@1.0.1':
+    optional: true
+
+  '@napi-rs/wasm-tools-darwin-arm64@1.0.1':
+    optional: true
+
+  '@napi-rs/wasm-tools-darwin-x64@1.0.1':
+    optional: true
+
+  '@napi-rs/wasm-tools-freebsd-x64@1.0.1':
+    optional: true
+
+  '@napi-rs/wasm-tools-linux-arm64-gnu@1.0.1':
+    optional: true
+
+  '@napi-rs/wasm-tools-linux-arm64-musl@1.0.1':
+    optional: true
+
+  '@napi-rs/wasm-tools-linux-x64-gnu@1.0.1':
+    optional: true
+
+  '@napi-rs/wasm-tools-linux-x64-musl@1.0.1':
+    optional: true
+
+  '@napi-rs/wasm-tools-wasm32-wasi@1.0.1':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
+    optional: true
+
+  '@napi-rs/wasm-tools-win32-arm64-msvc@1.0.1':
+    optional: true
+
+  '@napi-rs/wasm-tools-win32-ia32-msvc@1.0.1':
+    optional: true
+
+  '@napi-rs/wasm-tools-win32-x64-msvc@1.0.1':
+    optional: true
+
+  '@napi-rs/wasm-tools@1.0.1':
+    optionalDependencies:
+      '@napi-rs/wasm-tools-android-arm-eabi': 1.0.1
+      '@napi-rs/wasm-tools-android-arm64': 1.0.1
+      '@napi-rs/wasm-tools-darwin-arm64': 1.0.1
+      '@napi-rs/wasm-tools-darwin-x64': 1.0.1
+      '@napi-rs/wasm-tools-freebsd-x64': 1.0.1
+      '@napi-rs/wasm-tools-linux-arm64-gnu': 1.0.1
+      '@napi-rs/wasm-tools-linux-arm64-musl': 1.0.1
+      '@napi-rs/wasm-tools-linux-x64-gnu': 1.0.1
+      '@napi-rs/wasm-tools-linux-x64-musl': 1.0.1
+      '@napi-rs/wasm-tools-wasm32-wasi': 1.0.1
+      '@napi-rs/wasm-tools-win32-arm64-msvc': 1.0.1
+      '@napi-rs/wasm-tools-win32-ia32-msvc': 1.0.1
+      '@napi-rs/wasm-tools-win32-x64-msvc': 1.0.1
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -7129,6 +8058,69 @@ snapshots:
       mkdirp: 1.0.4
       rimraf: 3.0.2
     optional: true
+
+  '@octokit/auth-token@6.0.0': {}
+
+  '@octokit/core@7.0.6':
+    dependencies:
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.3
+      '@octokit/request': 10.0.8
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@11.0.3':
+    dependencies:
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@9.0.3':
+    dependencies:
+      '@octokit/request': 10.0.8
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/openapi-types@27.0.0': {}
+
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
+
+  '@octokit/plugin-request-log@6.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
+
+  '@octokit/request-error@7.1.0':
+    dependencies:
+      '@octokit/types': 16.0.0
+
+  '@octokit/request@10.0.8':
+    dependencies:
+      '@octokit/endpoint': 11.0.3
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      fast-content-type-parse: 3.0.0
+      json-with-bigint: 3.5.8
+      universal-user-agent: 7.0.3
+
+  '@octokit/rest@22.0.1':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-request-log': 6.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
+
+  '@octokit/types@16.0.0':
+    dependencies:
+      '@octokit/openapi-types': 27.0.0
 
   '@opentelemetry/api-logs@0.208.0':
     dependencies:
@@ -9065,6 +10057,8 @@ snapshots:
 
   batch-cluster@16.0.0: {}
 
+  before-after-hook@4.0.0: {}
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -9289,6 +10283,8 @@ snapshots:
       string-width: 4.2.3
     optional: true
 
+  cli-width@4.1.0: {}
+
   clip-filepaths-darwin-arm64@0.3.0:
     optional: true
 
@@ -9324,6 +10320,10 @@ snapshots:
       clip-filepaths-win32-arm64-msvc: 0.3.0
       clip-filepaths-win32-x64-msvc: 0.3.0
 
+  clipanion@4.0.0-rc.4(typanion@3.14.0):
+    dependencies:
+      typanion: 3.14.0
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -9352,6 +10352,8 @@ snapshots:
 
   color-support@1.1.3:
     optional: true
+
+  colorette@2.0.20: {}
 
   combined-stream@1.0.8:
     dependencies:
@@ -9666,6 +10668,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  emnapi@1.9.2(node-addon-api@7.1.1):
+    optionalDependencies:
+      node-addon-api: 7.1.1
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -9713,6 +10719,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  es-toolkit@1.45.1: {}
 
   es6-error@4.1.1:
     optional: true
@@ -9884,6 +10892,8 @@ snapshots:
     dependencies:
       pure-rand: 6.1.0
 
+  fast-content-type-parse@3.0.0: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -9898,7 +10908,17 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.0: {}
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fastq@1.20.1:
     dependencies:
@@ -10467,6 +11487,8 @@ snapshots:
 
   json-stringify-safe@5.0.1:
     optional: true
+
+  json-with-bigint@3.5.8: {}
 
   json5@2.2.3: {}
 
@@ -11149,6 +12171,8 @@ snapshots:
   mri@1.2.0: {}
 
   ms@2.1.3: {}
+
+  mute-stream@3.0.0: {}
 
   nanoid@3.3.11: {}
 
@@ -12281,6 +13305,8 @@ snapshots:
 
   tw-animate-css@1.4.0: {}
 
+  typanion@3.14.0: {}
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -12365,6 +13391,8 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
+
+  universal-user-agent@7.0.3: {}
 
   universalify@0.1.2: {}
 


### PR DESCRIPTION
## Summary

- 写真インデックスで必要な width/height の取得を、`@napi-rs/image` の `Transformer`（ファイル全体デコード）から `exif-native` の Rust 部分読み込み + Rayon 並列化に置き換え
- PNG: IHDR チャンク（先頭24バイト）から取得、JPEG: SOF マーカースキャン（先頭64KB以内）
- 5513枚のインデックスで 10〜50 倍の高速化が期待される

## Changes

| ファイル | 変更 |
|---------|------|
| `packages/exif-native/src/dimensions.rs` | 新規: PNG/JPEG サイズパーサー + Rust テスト14件 |
| `packages/exif-native/src/lib.rs` | `readImageDimensions` + `readImageDimensionsBatch` (napi) |
| `electron/lib/wrappedExifTool.ts` | インターフェース拡張 + ラッパー関数 |
| `electron/module/vrchatPhoto/vrchatPhoto.service.ts` | `processPhotoBatch` を同期関数に簡略化 |
| `electron/module/vrchatPhoto/vrchatPhoto.service.test.ts` | モック更新 |

## Why

従来の処理: `readFile`(数MB) → `Transformer`(全画像デコード) → `metadata()`(width/height)
新しい処理: Rust で先頭数十バイトだけ読み込み → ヘッダーパース → width/height

ファイル I/O が数MB→数十B に激減し、画像デコードが完全に不要になる。

## Test plan

- [x] Rust ユニットテスト 14件（PNG/JPEG 正常系・異常系・ファイルI/O）
- [x] TypeScript テスト 774件全パス
- [x] `pnpm lint` パス
- [ ] 実際の VRChat 写真ディレクトリでの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Faster photo library indexing via optimized image-dimension extraction
  * Batch dimension reads for improved bulk import and processing throughput
  * Skips photos with missing or unreadable dimensions to avoid index errors
  * More reliable dimension detection across PNG/JPEG formats
  * Reduced memory overhead during large-scale photo indexing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->