### PR TITLE
fix: DB初期化時のマイグレーションスキップが機能していないバグを修正

### DIFF
--- a/.changeset/fix-db-init-await.md
+++ b/.changeset/fix-db-init-await.md
@@ -1,0 +1,8 @@
+---
+'vrchat-albums': patch
+---
+
+fix: syncRDBClient のマイグレーションスキップが機能していなかったバグを修正
+
+match() の結果を await していなかったため、同一バージョンでの再起動時も
+毎回 7 テーブルの ALTER TABLE スキーマ比較が実行されていた。

--- a/electron/lib/sequelize.integration.test.ts
+++ b/electron/lib/sequelize.integration.test.ts
@@ -1,0 +1,90 @@
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn().mockReturnValue('/tmp/test'),
+    getVersion: vi.fn().mockReturnValue('1.0.0'),
+  },
+}));
+
+// getAppVersion をモックして、テスト内でバージョンを制御する。
+// pnpm 経由の実行時は process.env.npm_package_version が package.json の値になるため、
+// electron の getVersion モックだけではバージョンが一致しない可能性がある。
+vi.mock('./../module/settings/service', () => ({
+  getAppVersion: vi.fn().mockReturnValue('1.0.0-test'),
+}));
+
+/**
+ * syncRDBClient のマイグレーションスキップ動作を実DBで検証する統合テスト。
+ *
+ * 背景: match() の async コールバックが返す Promise<boolean> を await せずに
+ * truthy チェックしていたバグにより、同一バージョンでの再起動時も全テーブルの
+ * ALTER TABLE スキーマ比較が毎回実行されていた。
+ * このテストで、同一バージョンでの2回目の呼び出しがスキップされることを保証する。
+ */
+describe('syncRDBClient migration skip', () => {
+  beforeAll(async () => {
+    const client = await import('./sequelize');
+    await client.__initTestRDBClient();
+  }, 10000);
+
+  beforeEach(async () => {
+    const client = await import('./sequelize');
+    await client.__forceSyncRDBClient();
+  });
+
+  afterAll(async () => {
+    const client = await import('./sequelize');
+    await client.__cleanupTestRDBClient();
+  });
+
+  it('同一バージョンでの2回目の呼び出しはスキーマ同期をスキップする', async () => {
+    const client = await import('./sequelize');
+    const { Migrations } = await import('./sequelize/migrations.model');
+
+    // __forceSyncRDBClient はテーブルを再作成するが Migrations.create() も呼ぶ。
+    // テスト対象の syncRDBClient のみで検証するため、既存レコードをクリアする。
+    await Migrations.destroy({ where: {} });
+
+    // 1回目: checkRequired=true で通常フローを実行
+    // Migrations テーブルにバージョンが記録される
+    await client.syncRDBClient();
+    const countAfterFirst = await Migrations.count();
+    expect(countAfterFirst).toBe(1);
+
+    // 2回目: 同一バージョンなのでスキップされるべき
+    await client.syncRDBClient();
+    const countAfterSecond = await Migrations.count();
+
+    // スキップが正しく動作していれば、Migrations レコードは1のまま
+    // バグがあると executeSyncRDB が再実行され、レコードが2になる
+    expect(countAfterSecond).toBe(1);
+  });
+
+  it('checkMigrationRDBClient はバージョンが一致しない場合に true を返す', async () => {
+    const client = await import('./sequelize');
+    const { Migrations } = await import('./sequelize/migrations.model');
+
+    // beforeEach で __forceSyncRDBClient が実行され、Migrations に現バージョンが記録される。
+    // 異なるバージョンで migration check すると true（migration 必要）が返るべき。
+    const needsMigration =
+      await client.checkMigrationRDBClient('different-version');
+    expect(needsMigration).toBe(true);
+
+    // 現バージョンと同じなら false（スキップ）が返るべき
+    const latestMigration = await Migrations.findOne({
+      order: [['createdAt', 'DESC']],
+    });
+    const currentVersion = latestMigration?.version ?? '';
+    const noMigration = await client.checkMigrationRDBClient(currentVersion);
+    expect(noMigration).toBe(false);
+  });
+});

--- a/electron/lib/sequelize.ts
+++ b/electron/lib/sequelize.ts
@@ -193,18 +193,31 @@ const executeSyncRDB = async (options: { force: boolean }) => {
 
 /**
  * 必要に応じてデータベースを同期するラッパー関数。
+ *
+ * checkRequired=true（デフォルト）の場合、Migrations テーブルを確認し、
+ * 現在のアプリバージョンと一致する migration が既にあればスキーマ同期をスキップする。
+ * これにより同一バージョンでの再起動時に不要な ALTER TABLE を回避する。
  */
 export const syncRDBClient = async (options?: { checkRequired: boolean }) => {
-  // デフォルトは確認してから実行
   const checkRequired = options?.checkRequired ?? true;
   const appVersion = settingService.getAppVersion();
-  const migrationRequired = match(checkRequired)
-    .with(true, async () => checkMigrationRDBClient(appVersion))
-    .with(false, () => true);
+
+  // match() の結果を await して、async コールバックの Promise を正しく解決する。
+  // 旧コードでは await が欠落しており、Promise オブジェクト（truthy）が
+  // そのまま評価されていたため、スキップ判定が機能していなかった。
+  const migrationRequired = await match(checkRequired)
+    .with(true, () => checkMigrationRDBClient(appVersion))
+    .with(false, () => true)
+    .exhaustive();
 
   if (!migrationRequired) {
+    logger.info(
+      `syncRDBClient: schema already up-to-date for v${appVersion}, skipping sync`,
+    );
     return;
   }
+
+  logger.info(`syncRDBClient: migration required for v${appVersion}, syncing`);
   await executeSyncRDB({ force: false });
 };
 


### PR DESCRIPTION
## 概要

`syncRDBClient` で `match()` の結果を `await` していなかったため、同一バージョンでの再起動時もマイグレーションスキップが機能せず、毎回 7 テーブルの `ALTER TABLE` スキーマ比較が実行されていた。

## 原因

```typescript
// Before: match() の async コールバックが Promise<boolean> を返すが await されていない
const migrationRequired = match(checkRequired)
  .with(true, async () => checkMigrationRDBClient(appVersion))
  .with(false, () => true);

if (!migrationRequired) { // ← Promise は常に truthy → スキップされない
  return;
}
```

## 修正内容

- `match()` の結果を `await` して Promise を正しく解決
- `.exhaustive()` を追加して網羅性チェックを有効化
- 不要な `async` ラッパーを除去（`checkMigrationRDBClient` 自体が Promise を返す）
- スキップ時・実行時の `logger.info` を追加して可観測性を向上

## テスト

- 統合テストを追加（`electron/lib/sequelize.integration.test.ts`）
  - 同一バージョンでの2回目の呼び出しがスキップされること
  - `checkMigrationRDBClient` がバージョン不一致時に `true` を返すこと

## 影響

起動時の「データベースを初期化しています...」ステップが、同一バージョンでの再起動時にほぼ即座に完了するようになる。

https://claude.ai/code/session_017zEpi4mrYdgh8shSAkzN8C