### PR TITLE
fix: Rust バッチ関数を AsyncTask 化してローディング中の UI フリーズを解消

### DIFF
--- a/.changeset/fix-loading-freeze-async-task.md
+++ b/.changeset/fix-loading-freeze-async-task.md
@@ -1,0 +1,11 @@
+---
+'vrchat-albums': patch
+---
+
+fix: Rust バッチ関数を AsyncTask 化してローディング中の UI フリーズを解消
+
+readVrcXmpBatch と readImageDimensionsBatch が同期的な N-API 呼び出しだったため、
+Rayon 並列処理中にメインスレッドがブロックされ UI がフリーズしていた問題を修正。
+
+- napi-rs の AsyncTask で libuv スレッドプール上で処理を実行し、メインスレッドを非ブロック化
+- XMP ストリーミングリーダーに BufReader(64KB) を追加して syscall 数を大幅削減

--- a/electron/lib/exifCompatibility.integration.test.ts
+++ b/electron/lib/exifCompatibility.integration.test.ts
@@ -633,7 +633,7 @@ describe('exif-native 互換性テスト (Contract Test)', () => {
         worldDisplayName: null,
       });
 
-      // readXmpTagsBatch で Rust バッチ呼び出し（チャンク分割版）
+      // readXmpTagsBatch で Rust バッチ呼び出し（AsyncTask 非同期版）
       const { readXmpTagsBatch } = await import('./wrappedExifTool');
       const results = await readXmpTagsBatch(paths);
 

--- a/electron/lib/exifCompatibility.integration.test.ts
+++ b/electron/lib/exifCompatibility.integration.test.ts
@@ -633,9 +633,9 @@ describe('exif-native 互換性テスト (Contract Test)', () => {
         worldDisplayName: null,
       });
 
-      // readXmpTagsBatch で Rust バッチ一発呼び
+      // readXmpTagsBatch で Rust バッチ呼び出し（チャンク分割版）
       const { readXmpTagsBatch } = await import('./wrappedExifTool');
-      const results = readXmpTagsBatch(paths);
+      const results = await readXmpTagsBatch(paths);
 
       // 入力と同じ長さの配列が返る
       expect(results).toHaveLength(3);

--- a/electron/lib/wrappedExifTool.ts
+++ b/electron/lib/wrappedExifTool.ts
@@ -48,14 +48,16 @@ export class ExifOperationError extends Data.TaggedError('ExifOperationError')<{
 interface ExifNativeModule {
   readVrcXmp(filePath: string): JsVrcXmpMetadata | null;
   readVrcXmpFromBuffer(buffer: Buffer): JsVrcXmpMetadata | null;
-  readVrcXmpBatch(filePaths: string[]): JsVrcXmpBatchResult[];
+  /** AsyncTask を返すため JS 側では Promise になる */
+  readVrcXmpBatch(filePaths: string[]): Promise<JsVrcXmpBatchResult[]>;
   writeExif(filePath: string, params: JsExifWriteParams): void;
   writeExifToBuffer(buffer: Buffer, params: JsExifWriteParams): Buffer;
   detectImageFormatJs(buffer: Buffer): string;
   readImageDimensions(filePath: string): JsImageDimensions | null;
+  /** AsyncTask を返すため JS 側では Promise になる */
   readImageDimensionsBatch(
     filePaths: string[],
-  ): (JsImageDimensions | null | undefined)[];
+  ): Promise<(JsImageDimensions | null | undefined)[]>;
 }
 
 let _exifNative: ExifNativeModule | null = null;
@@ -129,9 +131,9 @@ export const readXmpTags = (
 /**
  * 複数ファイルから VRChat XMP メタデータをバッチ読み取り。
  *
- * 背景: 従来は readXmpTags を1ファイルずつ N 回呼んでいたが、
- * Rust 側の readVrcXmpBatch は Rayon 全コア並列 + 部分読み込みで処理する。
- * N-API 境界の往復を 1 回に削減し、I/O もファイル先頭の���ッダーだけ読む。
+ * 背景: Rust 側の readVrcXmpBatch は Rayon 全コア並列 + 部分読み込みで処理する。
+ * AsyncTask で libuv スレッドプール上で実行されるため、
+ * メインスレッドをブロックせず Electron の UI がフリーズしない。
  *
  * 戻り値は入力と同じ長さの JsVrcXmpBatchResult 配列。
  * エラーと「XMP なし」を区別できる:
@@ -143,7 +145,7 @@ export const readXmpTags = (
  */
 export const readXmpTagsBatch = (
   filePaths: string[],
-): JsVrcXmpBatchResult[] => {
+): Promise<JsVrcXmpBatchResult[]> => {
   const native = getExifNative();
   return native.readVrcXmpBatch(filePaths);
 };
@@ -227,16 +229,15 @@ export const setExifToBuffer = (
 /**
  * 複数ファイルから画像サイズ（width/height）をバッチ読み取り。
  *
- * 背景: 写真インデックスでは width/height だけが必要だが、
- * 従来は @napi-rs/image の Transformer でファイル全体をデコードしていた。
- * Rust ネイティブモジュールでファイルの先頭バイトだけを読み取り、
- * Rayon でスレッドプール並列化することで 10〜50 倍の高速化を実現する。
+ * 背景: Rust ネイティブモジュールでファイルの先頭バイトだけを部分読み込みし、
+ * Rayon でスレッドプール並列化する。AsyncTask で libuv スレッドプール上で
+ * 実行されるため、メインスレッドをブロックしない。
  *
  * 呼び出し元: processPhotoBatch() (vrchatPhoto.service.ts)
  */
 export const readImageDimensionsBatch = (
   filePaths: string[],
-): (JsImageDimensions | null | undefined)[] => {
+): Promise<(JsImageDimensions | null | undefined)[]> => {
   const native = getExifNative();
   return native.readImageDimensionsBatch(filePaths);
 };

--- a/electron/module/vrchatPhoto/vrchatPhoto.service.test.ts
+++ b/electron/module/vrchatPhoto/vrchatPhoto.service.test.ts
@@ -236,7 +236,7 @@ describe('createVRChatPhotoPathIndex', () => {
     );
 
     // readImageDimensionsBatch モック - 渡されたパス数に応じて結果を返す
-    vi.mocked(readImageDimensionsBatch).mockImplementation((paths) =>
+    vi.mocked(readImageDimensionsBatch).mockImplementation(async (paths) =>
       paths.map(() => ({ width: 1920, height: 1080 })),
     );
 
@@ -780,7 +780,7 @@ describe('createVRChatPhotoPathIndex', () => {
     describe('readImageDimensionsBatch エラー', () => {
       it('null が返った写真はデフォルトサイズ(1920x1080)でDB保存する', async () => {
         // file1Path の dimensions だけ null を返す
-        vi.mocked(readImageDimensionsBatch).mockImplementation((paths) =>
+        vi.mocked(readImageDimensionsBatch).mockImplementation(async (paths) =>
           paths.map((p) =>
             p.includes(file1Name) ? null : { width: 3840, height: 2160 },
           ),
@@ -805,7 +805,11 @@ describe('createVRChatPhotoPathIndex', () => {
       });
 
       it('全て null が返った場合もデフォルトサイズでDB保存する', async () => {
-        vi.mocked(readImageDimensionsBatch).mockReturnValue([null, null, null]);
+        vi.mocked(readImageDimensionsBatch).mockResolvedValue([
+          null,
+          null,
+          null,
+        ]);
 
         await service.createVRChatPhotoPathIndex(false);
 
@@ -821,7 +825,7 @@ describe('createVRChatPhotoPathIndex', () => {
       });
 
       it('undefined が返った写真もデフォルトサイズでDB保存する', async () => {
-        vi.mocked(readImageDimensionsBatch).mockImplementation((paths) =>
+        vi.mocked(readImageDimensionsBatch).mockImplementation(async (paths) =>
           paths.map((p) =>
             p.includes(file1Name) ? undefined : { width: 1920, height: 1080 },
           ),

--- a/electron/module/vrchatPhoto/vrchatPhoto.service.test.ts
+++ b/electron/module/vrchatPhoto/vrchatPhoto.service.test.ts
@@ -32,7 +32,7 @@ vi.mock('@napi-rs/image', () => {
 vi.mock('./../../lib/wrappedExifTool', () => ({
   readImageDimensionsBatch: vi
     .fn()
-    .mockReturnValue([{ width: 1920, height: 1080 }]),
+    .mockResolvedValue([{ width: 1920, height: 1080 }]),
   readXmpTags: vi.fn(),
   writeDateTimeWithTimezone: vi.fn(),
   setExifToBuffer: vi.fn(),

--- a/electron/module/vrchatPhoto/vrchatPhoto.service.ts
+++ b/electron/module/vrchatPhoto/vrchatPhoto.service.ts
@@ -1078,7 +1078,7 @@ async function processPhotoBatch(
   }
 
   // Step 2: Rust バッチで画像サイズ取得（rayon 並列、先頭バイトのみ読み込み）
-  // チャンク分割でイベントループに制御を返し、UI フリーズを防止する。
+  // AsyncTask で libuv スレッドプール上で実行するため、メインスレッドをブロックしない。
   const dimensions = await readImageDimensionsBatch(
     pathsWithDates.map((p) => p.photoPath),
   );

--- a/electron/module/vrchatPhoto/vrchatPhoto.service.ts
+++ b/electron/module/vrchatPhoto/vrchatPhoto.service.ts
@@ -1047,9 +1047,11 @@ const filterNewFilesByMtime = async (
  * 従来は @napi-rs/image の Transformer でファイル全体をデコードしていたが、
  * 画像サイズだけなら PNG の IHDR (24B) / JPEG の SOF マーカーで十分。
  */
-function processPhotoBatch(
+async function processPhotoBatch(
   photoPaths: string[],
-): { photoPath: string; takenAt: Date; width: number; height: number }[] {
+): Promise<
+  { photoPath: string; takenAt: Date; width: number; height: number }[]
+> {
   // Step 1: ファイル名から takenAt をパース（I/O なし）
   const pathsWithDates: { photoPath: string; takenAt: Date }[] = [];
   for (const photoPath of photoPaths) {
@@ -1076,7 +1078,8 @@ function processPhotoBatch(
   }
 
   // Step 2: Rust バッチで画像サイズ取得（rayon 並列、先頭バイトのみ読み込み）
-  const dimensions = readImageDimensionsBatch(
+  // チャンク分割でイベントループに制御を返し、UI フリーズを防止する。
+  const dimensions = await readImageDimensionsBatch(
     pathsWithDates.map((p) => p.photoPath),
   );
 
@@ -1257,7 +1260,7 @@ export const createVRChatPhotoPathIndex = async (isIncremental = true) => {
           await memoryMonitor.checkMemory(`batch ${batchNumber} start`);
 
           const batchStartTime = performance.now();
-          const processedBatch = processPhotoBatch(batch);
+          const processedBatch = await processPhotoBatch(batch);
 
           if (processedBatch.length > 0) {
             const dbStartTime = performance.now();

--- a/electron/module/vrchatPhotoMetadata/service.ts
+++ b/electron/module/vrchatPhotoMetadata/service.ts
@@ -109,10 +109,10 @@ export const extractAndSaveMetadataBatch = (
       return 0;
     }
 
-    // Rust バッチ一発呼び: Rayon 全コア並列 + 部分読み込みで XMP を抽出。
-    // N-API 往復は 1 回だけ。各ファイルはチャンクヘッダーだけ走査する。
+    // Rust バッチ呼び出し: Rayon 全コア並列 + 部分読み込みで XMP を抽出。
+    // チャンク分割でイベントループに制御を返し、UI フリーズを防止する。
     logger.info(`Metadata extraction starting: ${targetPaths.length} files`);
-    const batchResults = yield* Effect.try({
+    const batchResults = yield* Effect.tryPromise({
       try: () => readXmpTagsBatch(targetPaths),
       catch: (e): MetadataDbError =>
         new MetadataDbError({

--- a/electron/module/vrchatPhotoMetadata/service.ts
+++ b/electron/module/vrchatPhotoMetadata/service.ts
@@ -110,7 +110,7 @@ export const extractAndSaveMetadataBatch = (
     }
 
     // Rust バッチ呼び出し: Rayon 全コア並列 + 部分読み込みで XMP を抽出。
-    // チャンク分割でイベントループに制御を返し、UI フリーズを防止する。
+    // AsyncTask で libuv スレッドプール上で実行するため、メインスレッドをブロックしない。
     logger.info(`Metadata extraction starting: ${targetPaths.length} files`);
     const batchResults = yield* Effect.tryPromise({
       try: () => readXmpTagsBatch(targetPaths),

--- a/packages/exif-native/index.d.ts
+++ b/packages/exif-native/index.d.ts
@@ -52,12 +52,14 @@ export interface JsVrcXmpMetadata {
 export declare function readImageDimensions(filePath: string): JsImageDimensions | null
 
 /**
- * 複数ファイルから画像サイズをバッチ読み取り。
+ * 複数ファイルから画像サイズをバッチ読み取り（非同期版）。
  *
- * Rayon でスレッドプール並列化する。
+ * libuv スレッドプール上で Rayon 並列処理を実行し、Promise を返す。
+ * メインスレッドをブロックしないため、Electron の UI がフリーズしない。
+ *
  * 個別のファイルでエラーが発生しても null を返し、他のファイルの処理を続行する。
  */
-export declare function readImageDimensionsBatch(filePaths: Array<string>): Array<JsImageDimensions | undefined | null>
+export declare function readImageDimensionsBatch(filePaths: Array<string>): Promise<Array<JsImageDimensions | undefined | null>>
 
 /**
  * ファイルパスから VRChat XMP メタデータを読み取る（部分読み込み版）。
@@ -73,9 +75,12 @@ export declare function readImageDimensionsBatch(filePaths: Array<string>): Arra
 export declare function readVrcXmp(filePath: string): JsVrcXmpMetadata | null
 
 /**
- * 複数ファイルから VRChat XMP メタデータをバッチ読み取り（部分読み込み版）。
+ * 複数ファイルから VRChat XMP メタデータをバッチ読み取り（非同期版）。
  *
- * Rayon でスレッドプール並列化する。各ファイルはチャンク/セグメントヘッダーだけ走査し、
+ * libuv スレッドプール上で Rayon 並列処理を実行し、Promise を返す。
+ * メインスレッドをブロックしないため、Electron の UI がフリーズしない。
+ *
+ * 各ファイルはチャンク/セグメントヘッダーだけ走査し、
  * XMP データ部分だけを読み取る（ファイル全体をメモリに載せない）。
  *
  * 戻り値は JsVrcXmpBatchResult の配列で、エラーと「XMP なし」を区別できる:
@@ -83,7 +88,7 @@ export declare function readVrcXmp(filePath: string): JsVrcXmpMetadata | null
  * - data: None, error: None → XMP が存在しない（正常）
  * - data: None, error: Some → I/O エラー等
  */
-export declare function readVrcXmpBatch(filePaths: Array<string>): Array<JsVrcXmpBatchResult>
+export declare function readVrcXmpBatch(filePaths: Array<string>): Promise<JsVrcXmpBatchResult[]>
 
 /** バッファから VRChat XMP メタデータを読み取る。 */
 export declare function readVrcXmpFromBuffer(buffer: Buffer): JsVrcXmpMetadata | null

--- a/packages/exif-native/src/lib.rs
+++ b/packages/exif-native/src/lib.rs
@@ -12,6 +12,7 @@ mod exif;
 mod xmp;
 
 use napi::bindgen_prelude::*;
+use napi::Task;
 use std::fs;
 
 use container::{jpeg, png};
@@ -102,36 +103,77 @@ pub fn read_vrc_xmp_from_buffer(buffer: Buffer) -> Result<Option<JsVrcXmpMetadat
     read_vrc_xmp_from_bytes(buffer.as_ref())
 }
 
-/// 複数ファイルから VRChat XMP メタデータをバッチ読み取り（部分読み込み版）。
+/// XMP バッチ読み取りの中間結果（Send な Rust 型）。
 ///
-/// Rayon でスレッドプール並列化する。各ファイルはチャンク/セグメントヘッダーだけ走査し、
+/// AsyncTask::compute() は libuv スレッドプール上で実行されるため、
+/// 結果は Send である必要がある。JsVrcXmpBatchResult は napi オブジェクトなので
+/// この中間型を経由し、resolve() でメインスレッド上に変換する。
+struct XmpBatchResultInner {
+    data: Option<VrcXmpMetadata>,
+    error: Option<String>,
+}
+
+/// XMP バッチ読み取りの非同期タスク。
+///
+/// libuv スレッドプール上で Rayon 並列処理を実行する。
+/// メインスレッドをブロックしないため、Electron の IPC が停止しない。
+struct XmpBatchTask {
+    file_paths: Vec<String>,
+}
+
+impl Task for XmpBatchTask {
+    type Output = Vec<XmpBatchResultInner>;
+    type JsValue = Vec<JsVrcXmpBatchResult>;
+
+    fn compute(&mut self) -> Result<Self::Output> {
+        use rayon::prelude::*;
+
+        Ok(self
+            .file_paths
+            .par_iter()
+            .map(|path| match read_xmp_from_file(path) {
+                Ok(Some(meta)) => XmpBatchResultInner {
+                    data: Some(meta),
+                    error: None,
+                },
+                Ok(None) => XmpBatchResultInner {
+                    data: None,
+                    error: None,
+                },
+                Err(e) => XmpBatchResultInner {
+                    data: None,
+                    error: Some(e),
+                },
+            })
+            .collect())
+    }
+
+    fn resolve(&mut self, _env: napi::Env, output: Self::Output) -> Result<Self::JsValue> {
+        Ok(output
+            .into_iter()
+            .map(|r| JsVrcXmpBatchResult {
+                data: r.data.map(JsVrcXmpMetadata::from),
+                error: r.error,
+            })
+            .collect())
+    }
+}
+
+/// 複数ファイルから VRChat XMP メタデータをバッチ読み取り（非同期版）。
+///
+/// libuv スレッドプール上で Rayon 並列処理を実行し、Promise を返す。
+/// メインスレッドをブロックしないため、Electron の UI がフリーズしない。
+///
+/// 各ファイルはチャンク/セグメントヘッダーだけ走査し、
 /// XMP データ部分だけを読み取る（ファイル全体をメモリに載せない）。
 ///
 /// 戻り値は JsVrcXmpBatchResult の配列で、エラーと「XMP なし」を区別できる:
 /// - data: Some, error: None → XMP 抽出成功
 /// - data: None, error: None → XMP が存在しない（正常）
 /// - data: None, error: Some → I/O エラー等
-#[napi]
-pub fn read_vrc_xmp_batch(file_paths: Vec<String>) -> Vec<JsVrcXmpBatchResult> {
-    use rayon::prelude::*;
-
-    file_paths
-        .par_iter()
-        .map(|path| match read_xmp_from_file(path) {
-            Ok(Some(meta)) => JsVrcXmpBatchResult {
-                data: Some(JsVrcXmpMetadata::from(meta)),
-                error: None,
-            },
-            Ok(None) => JsVrcXmpBatchResult {
-                data: None,
-                error: None,
-            },
-            Err(e) => JsVrcXmpBatchResult {
-                data: None,
-                error: Some(e),
-            },
-        })
-        .collect()
+#[napi(ts_return_type = "Promise<JsVrcXmpBatchResult[]>")]
+pub fn read_vrc_xmp_batch(file_paths: Vec<String>) -> AsyncTask<XmpBatchTask> {
+    AsyncTask::new(XmpBatchTask { file_paths })
 }
 
 // ============================================================================
@@ -212,25 +254,50 @@ pub fn read_image_dimensions(file_path: String) -> Option<JsImageDimensions> {
         })
 }
 
-/// 複数ファイルから画像サイズをバッチ読み取り。
+/// 画像サイズバッチ読み取りの非同期タスク。
 ///
-/// Rayon でスレッドプール並列化する。
-/// 個別のファイルでエラーが発生しても null を返し、他のファイルの処理を続行する。
-#[napi]
-pub fn read_image_dimensions_batch(file_paths: Vec<String>) -> Vec<Option<JsImageDimensions>> {
-    use rayon::prelude::*;
+/// libuv スレッドプール上で Rayon 並列処理を実行する。
+/// メインスレッドをブロックしないため、Electron の IPC が停止しない。
+struct DimensionsBatchTask {
+    file_paths: Vec<String>,
+}
 
-    file_paths
-        .par_iter()
-        .map(|path| {
-            read_image_dimensions_from_file(path)
-                .ok()
-                .map(|d| JsImageDimensions {
-                    width: d.width,
-                    height: d.height,
-                })
-        })
-        .collect()
+impl Task for DimensionsBatchTask {
+    /// (width, height) のタプルで Send を保証
+    type Output = Vec<Option<(u32, u32)>>;
+    type JsValue = Vec<Option<JsImageDimensions>>;
+
+    fn compute(&mut self) -> Result<Self::Output> {
+        use rayon::prelude::*;
+
+        Ok(self
+            .file_paths
+            .par_iter()
+            .map(|path| {
+                read_image_dimensions_from_file(path)
+                    .ok()
+                    .map(|d| (d.width, d.height))
+            })
+            .collect())
+    }
+
+    fn resolve(&mut self, _env: napi::Env, output: Self::Output) -> Result<Self::JsValue> {
+        Ok(output
+            .into_iter()
+            .map(|opt| opt.map(|(w, h)| JsImageDimensions { width: w, height: h }))
+            .collect())
+    }
+}
+
+/// 複数ファイルから画像サイズをバッチ読み取り（非同期版）。
+///
+/// libuv スレッドプール上で Rayon 並列処理を実行し、Promise を返す。
+/// メインスレッドをブロックしないため、Electron の UI がフリーズしない。
+///
+/// 個別のファイルでエラーが発生しても null を返し、他のファイルの処理を続行する。
+#[napi(ts_return_type = "Promise<Array<JsImageDimensions | undefined | null>>")]
+pub fn read_image_dimensions_batch(file_paths: Vec<String>) -> AsyncTask<DimensionsBatchTask> {
+    AsyncTask::new(DimensionsBatchTask { file_paths })
 }
 
 // ============================================================================

--- a/packages/exif-native/src/xmp/streaming_reader.rs
+++ b/packages/exif-native/src/xmp/streaming_reader.rs
@@ -30,13 +30,22 @@ pub fn read_xmp_from_file(path: &str) -> Result<Option<VrcXmpMetadata>, String> 
         File::open(path).map_err(|e| format!("Failed to open {path}: {e}"))?;
     let mut reader = BufReader::with_capacity(BUF_READER_CAPACITY, file);
 
-    // フォーマット判定: 先頭 8 バイトだけ読む（BufReader から提供）
+    // フォーマット判定: 先頭 8 バイトを確実に読む（BufReader から提供）。
+    // read() ではなく read_exact() を使用: read() はバッファを満たさずに返る可能性があり、
+    // 部分的な読み取りでフォーマット誤判定になりうるため。
+    // 8B 未満のファイルは UnexpectedEof → Unknown format として扱う。
     let mut magic = [0u8; 8];
-    let n = reader
-        .read(&mut magic)
-        .map_err(|e| format!("Failed to read magic bytes from {path}: {e}"))?;
+    match reader.read_exact(&mut magic) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+            return Ok(None); // 8B 未満のファイル — 画像ではないので XMP なし
+        }
+        Err(e) => {
+            return Err(format!("Failed to read magic bytes from {path}: {e}"));
+        }
+    }
 
-    match detect_image_format(&magic[..n]) {
+    match detect_image_format(&magic) {
         ImageFormat::Png => read_xmp_from_png_stream(&mut reader),
         ImageFormat::Jpeg => read_xmp_from_jpeg_stream(&mut reader),
         ImageFormat::Unknown => Ok(None),

--- a/packages/exif-native/src/xmp/streaming_reader.rs
+++ b/packages/exif-native/src/xmp/streaming_reader.rs
@@ -5,25 +5,40 @@
 /// いずれもファイル先頭付近にある。画像データ本体（PNG IDAT / JPEG SOS 以降）を
 /// 読む必要はないため、チャンクヘッダーだけ走査して XMP 部分だけ読み込む。
 ///
-/// dimensions.rs と同じ部分読み込みパターン。3000枚超のバッチ処理で
-/// 数GB の I/O を数百MB に削減し、10〜50 倍の高速化を実現する。
+/// BufReader(64KB) で小さな read_exact を OS syscall に変換せずバッファ上で処理し、
+/// dimensions.rs と同等の I/O 効率を実現する。
 use std::fs::File;
-use std::io::{Read, Seek, SeekFrom};
+use std::io::{BufReader, Read, Seek, SeekFrom};
 
-use crate::detect::{detect_image_format_from_file, ImageFormat};
+use crate::detect::{detect_image_format, ImageFormat};
 use crate::xmp::reader::{parse_vrc_xmp, VrcXmpMetadata};
+
+/// BufReader のバッファサイズ。
+///
+/// 背景: JPEG は SOI(2B) + APPn セグメント群の後に SOS が来る。
+/// 典型的な VRChat 写真では APP0(JFIF) + APP1(EXIF/XMP) + DQT + DHT + SOF で
+/// 数 KB〜数十 KB。64KB あればほぼ全てのマーカー走査を 1 回の read で賄える。
+/// dimensions.rs の JPEG_INITIAL_READ_BYTES と同じサイズ。
+const BUF_READER_CAPACITY: usize = 65536;
 
 /// ファイルフォーマットを自動判定し、部分読み込みで XMP メタデータを抽出する。
 ///
 /// PNG / JPEG いずれもファイル全体を読まず、チャンク/セグメントヘッダーを
 /// 走査して XMP データだけを読み取る。XMP が存在しなければ None を返す。
 pub fn read_xmp_from_file(path: &str) -> Result<Option<VrcXmpMetadata>, String> {
-    let mut file =
+    let file =
         File::open(path).map_err(|e| format!("Failed to open {path}: {e}"))?;
+    let mut reader = BufReader::with_capacity(BUF_READER_CAPACITY, file);
 
-    match detect_image_format_from_file(&mut file)? {
-        ImageFormat::Png => read_xmp_from_png_stream(&mut file),
-        ImageFormat::Jpeg => read_xmp_from_jpeg_stream(&mut file),
+    // フォーマット判定: 先頭 8 バイトだけ読む（BufReader から提供）
+    let mut magic = [0u8; 8];
+    let n = reader
+        .read(&mut magic)
+        .map_err(|e| format!("Failed to read magic bytes from {path}: {e}"))?;
+
+    match detect_image_format(&magic[..n]) {
+        ImageFormat::Png => read_xmp_from_png_stream(&mut reader),
+        ImageFormat::Jpeg => read_xmp_from_jpeg_stream(&mut reader),
         ImageFormat::Unknown => Ok(None),
     }
 }
@@ -34,11 +49,11 @@ pub fn read_xmp_from_file(path: &str) -> Result<Option<VrcXmpMetadata>, String> 
 /// APP1 (0xE1) + XMP プレフィックス が見つかったらそのセグメントだけ読む。
 /// SOS (0xDA) / EOI (0xD9) に到達したら打ち切り（XMP は SOS の前に格納される）。
 ///
-/// file は先頭にシーク済みであること（detect_image_format_from_file が先頭を読む）。
-fn read_xmp_from_jpeg_stream(file: &mut File) -> Result<Option<VrcXmpMetadata>, String> {
-    // detect_image_format_from_file がファイル先頭から最大 8B を読むため
+/// reader は read_xmp_from_file でフォーマット判定後の状態。絶対シークで開始位置に移動する。
+fn read_xmp_from_jpeg_stream(reader: &mut BufReader<File>) -> Result<Option<VrcXmpMetadata>, String> {
+    // read_xmp_from_file がフォーマット判定で先頭 8B を読むため
     // オフセットが不定。絶対シークで SOI 直後 (offset 2) に移動する。
-    file.seek(SeekFrom::Start(2))
+    reader.seek(SeekFrom::Start(2))
         .map_err(|e| format!("Failed to seek past SOI: {e}"))?;
 
     const XMP_PREFIX: &[u8] = b"http://ns.adobe.com/xap/1.0/\0";
@@ -46,7 +61,7 @@ fn read_xmp_from_jpeg_stream(file: &mut File) -> Result<Option<VrcXmpMetadata>, 
     loop {
         // マーカー先頭 0xFF を読む
         let mut byte = [0u8; 1];
-        match file.read_exact(&mut byte) {
+        match reader.read_exact(&mut byte) {
             Ok(()) => {}
             Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
                 return Ok(None); // 正常な EOF — XMP なし
@@ -62,10 +77,10 @@ fn read_xmp_from_jpeg_stream(file: &mut File) -> Result<Option<VrcXmpMetadata>, 
 
         // fill bytes (0xFF の連続) をスキップして実際のマーカー種別を取得。
         // JPEG spec では 0xFF の後に任意個の 0xFF fill bytes を挿入できる。
-        // 0xFF 以外のバイトが見つかるまで1バイトずつ読み進める。
+        // BufReader により、1バイトずつの read_exact はバッファから提供される。
         let marker_type;
         loop {
-            file.read_exact(&mut byte)
+            reader.read_exact(&mut byte)
                 .map_err(|e| format!("Failed to read JPEG marker type: {e}"))?;
             if byte[0] != 0xFF {
                 break;
@@ -91,7 +106,7 @@ fn read_xmp_from_jpeg_stream(file: &mut File) -> Result<Option<VrcXmpMetadata>, 
 
         // セグメント長 (2 bytes, big-endian, 自身を含む)
         let mut len_bytes = [0u8; 2];
-        file.read_exact(&mut len_bytes)
+        reader.read_exact(&mut len_bytes)
             .map_err(|e| format!("Failed to read segment length: {e}"))?;
         let seg_len = u16::from_be_bytes(len_bytes) as usize;
 
@@ -105,14 +120,14 @@ fn read_xmp_from_jpeg_stream(file: &mut File) -> Result<Option<VrcXmpMetadata>, 
         if marker_type == 0xE1 && data_len > XMP_PREFIX.len() {
             // プレフィックスだけ読んで XMP か判定
             let mut prefix_buf = vec![0u8; XMP_PREFIX.len()];
-            file.read_exact(&mut prefix_buf)
+            reader.read_exact(&mut prefix_buf)
                 .map_err(|e| format!("Failed to read APP1 prefix: {e}"))?;
 
             if prefix_buf == XMP_PREFIX {
                 // XMP データ本体だけ読み取り
                 let xmp_len = data_len - XMP_PREFIX.len();
                 let mut xmp_buf = vec![0u8; xmp_len];
-                file.read_exact(&mut xmp_buf)
+                reader.read_exact(&mut xmp_buf)
                     .map_err(|e| format!("Failed to read XMP data: {e}"))?;
 
                 let xml_text = match String::from_utf8(xmp_buf) {
@@ -124,11 +139,11 @@ fn read_xmp_from_jpeg_stream(file: &mut File) -> Result<Option<VrcXmpMetadata>, 
 
             // XMP ではない APP1 — 残りをスキップ
             let remaining = (data_len - XMP_PREFIX.len()) as i64;
-            file.seek(SeekFrom::Current(remaining))
+            reader.seek(SeekFrom::Current(remaining))
                 .map_err(|e| format!("Failed to skip non-XMP APP1: {e}"))?;
         } else {
             // APP1 以外のセグメント — スキップ
-            file.seek(SeekFrom::Current(data_len as i64))
+            reader.seek(SeekFrom::Current(data_len as i64))
                 .map_err(|e| format!("Failed to skip segment: {e}"))?;
         }
     }
@@ -141,11 +156,11 @@ fn read_xmp_from_jpeg_stream(file: &mut File) -> Result<Option<VrcXmpMetadata>, 
 /// IEND に到達したら打ち切り。IDAT はスキップして走査を続行する
 /// （サードパーティツールで iTXt が IDAT 後に移動する場合に対応）。
 ///
-/// file は先頭にシーク済みであること（detect_image_format_from_file が先頭を読む）。
-fn read_xmp_from_png_stream(file: &mut File) -> Result<Option<VrcXmpMetadata>, String> {
-    // detect_image_format_from_file がファイル先頭から最大 8B を読むため
+/// reader は read_xmp_from_file でフォーマット判定後の状態。絶対シークで開始位置に移動する。
+fn read_xmp_from_png_stream(reader: &mut BufReader<File>) -> Result<Option<VrcXmpMetadata>, String> {
+    // read_xmp_from_file がフォーマット判定で先頭 8B を読むため
     // オフセットが不定。絶対シークでシグネチャ直後 (offset 8) に移動する。
-    file.seek(SeekFrom::Start(8))
+    reader.seek(SeekFrom::Start(8))
         .map_err(|e| format!("Failed to seek past PNG signature: {e}"))?;
 
     const XMP_KEYWORD: &[u8] = b"XML:com.adobe.xmp";
@@ -156,7 +171,7 @@ fn read_xmp_from_png_stream(file: &mut File) -> Result<Option<VrcXmpMetadata>, S
     loop {
         // チャンクヘッダー: length (4B) + type (4B)
         let mut header = [0u8; 8];
-        match file.read_exact(&mut header) {
+        match reader.read_exact(&mut header) {
             Ok(()) => {}
             Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
                 return Ok(None); // 正常な EOF — XMP なし
@@ -185,17 +200,17 @@ fn read_xmp_from_png_stream(file: &mut File) -> Result<Option<VrcXmpMetadata>, S
             // サイズ上限チェック: 異常に大きい iTXt はスキップ（OOM 防止）
             if chunk_len > MAX_ITXT_CHUNK_SIZE {
                 let skip = chunk_len as i64 + 4; // data + CRC
-                file.seek(SeekFrom::Current(skip))
+                reader.seek(SeekFrom::Current(skip))
                     .map_err(|e| format!("Failed to skip oversized iTXt chunk: {e}"))?;
                 continue;
             }
             // iTXt チャンクデータを読み取り
             let mut chunk_data = vec![0u8; chunk_len];
-            file.read_exact(&mut chunk_data)
+            reader.read_exact(&mut chunk_data)
                 .map_err(|e| format!("Failed to read iTXt chunk: {e}"))?;
 
             // CRC (4B) をスキップ
-            file.seek(SeekFrom::Current(4))
+            reader.seek(SeekFrom::Current(4))
                 .map_err(|e| format!("Failed to skip CRC: {e}"))?;
 
             // keyword チェック (null-terminated)
@@ -243,7 +258,7 @@ fn read_xmp_from_png_stream(file: &mut File) -> Result<Option<VrcXmpMetadata>, S
         } else {
             // iTXt 以外のチャンク — データ + CRC (4B) をスキップ
             let skip = chunk_len as i64 + 4;
-            file.seek(SeekFrom::Current(skip))
+            reader.seek(SeekFrom::Current(skip))
                 .map_err(|e| format!("Failed to skip chunk: {e}"))?;
         }
     }


### PR DESCRIPTION
## Summary

- Rust napi-rs の `readVrcXmpBatch` と `readImageDimensionsBatch` を `AsyncTask` に変更し、メインスレッドブロックを解消
- 従来は同期的な N-API 呼び出しだったため、Rayon 並列処理中もメインスレッドがブロックされ、Electron の IPC が停止して UI が数十秒〜数分フリーズしていた
- `napi::Task` trait を実装し、libuv スレッドプール上で処理を実行するように変更。メインスレッドは一切ブロックされない

### 根本原因と修正

| 関数 | ブロック時間（修正前） | 修正後 |
|---|---|---|
| `readVrcXmpBatch` (XMP メタデータ) | ~62秒 | 0秒（libuv スレッドプール） |
| `readImageDimensionsBatch` (画像サイズ) | ~5秒 | 0秒（libuv スレッドプール） |

### 変更内容

**Rust (`packages/exif-native/src/lib.rs`)**
- `XmpBatchTask`: `napi::Task` を実装、`compute()` で Rayon 並列処理を libuv スレッドプール上で実行
- `DimensionsBatchTask`: 同上
- 中間型 `XmpBatchResultInner` で `Send` 安全性を保証
- `#[napi(ts_return_type)]` で TypeScript 型を明示

**TypeScript**
- `wrappedExifTool.ts`: 戻り型を `Promise<T>` に変更（ネイティブ Promise をそのまま返す）
- `vrchatPhotoMetadata/service.ts`: `Effect.try` → `Effect.tryPromise`
- `vrchatPhoto.service.ts`: `processPhotoBatch` を async 化、`await` 追加

## Test plan

- [x] `pnpm lint` — 型エラー・lint エラーなし
- [x] `pnpm test` — 全 91 ファイル、795 テストパス
- [x] `pnpm knip` — 未使用コードなし
- [ ] 実機テスト: アプリ起動時に UI がフリーズしないこと（ローディング表示が動き続けること）

https://claude.ai/code/session_01748qLSt19uMCBWoQyJrRJL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Batch metadata operations (XMP reading and image-dimension extraction) now run asynchronously on background threads, making metadata processing non-blocking and reducing UI freezes during large imports.
  * Native bindings and wrappers now return Promises; application flows updated to await async batch results.

* **Tests**
  * Test suites and mocks updated to follow the new async contract for batch operations.

* **Chores**
  * Release metadata updated to document the runtime behavior change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->