### PR TITLE
refactor: デザインシステムを洗練 — Arc/Apple風のエレガントなUIへ

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,26 +5,27 @@ import * as React from 'react';
 import { cn } from '../lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors duration-150 ease-spring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium ring-offset-background transition-all duration-200 ease-spring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {
-        default: 'glass-button text-primary-foreground',
+        default:
+          'glass-button text-primary-foreground hover:shadow-glow active:scale-[0.98]',
         destructive:
-          'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+          'bg-destructive text-destructive-foreground hover:bg-destructive/90 active:scale-[0.98]',
         outline:
-          'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+          'bg-background hover:bg-muted/60 hover:shadow-subtle active:scale-[0.98]',
         secondary:
-          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-        ghost: 'hover:bg-accent hover:text-accent-foreground',
+          'bg-secondary text-secondary-foreground hover:bg-secondary/70 active:scale-[0.98]',
+        ghost: 'hover:bg-muted/50 hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline',
         icon: '',
-        glass: 'glass border border-glass-border hover:shadow-glass-hover',
+        glass: 'glass hover:shadow-glass-hover active:scale-[0.98]',
       },
       size: {
         default: 'h-10 px-4 py-2',
-        sm: 'h-9 rounded-md px-3',
-        lg: 'h-11 rounded-md px-8',
+        sm: 'h-9 rounded-lg px-3',
+        lg: 'h-11 rounded-xl px-8',
         icon: 'h-10 w-10',
       },
     },

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,24 +5,21 @@ import * as React from 'react';
 import { cn } from '../lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors duration-150 ease-spring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {
-        default:
-          'glass-button text-primary-foreground hover:shadow-glass-hover hover:scale-105',
+        default: 'glass-button text-primary-foreground',
         destructive:
-          'bg-destructive/80 backdrop-blur-sm border border-destructive/30 text-destructive-foreground hover:bg-destructive/90 hover:scale-105',
+          'bg-destructive text-destructive-foreground hover:bg-destructive/90',
         outline:
-          'border border-input/50 backdrop-blur-sm bg-background/50 hover:bg-accent/80 hover:text-accent-foreground hover:scale-105',
+          'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
         secondary:
-          'backdrop-blur-sm bg-secondary/80 border border-secondary/30 text-secondary-foreground hover:bg-secondary/90 hover:scale-105',
-        ghost:
-          'backdrop-blur-sm hover:bg-accent/60 hover:text-accent-foreground hover:scale-105',
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline',
         icon: '',
-        glass:
-          'glass backdrop-blur-md border border-glass-border hover:shadow-glass-hover hover:scale-105',
+        glass: 'glass border border-glass-border hover:shadow-glass-hover',
       },
       size: {
         default: 'h-10 px-4 py-2',

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -50,7 +50,7 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-5 top-5 rounded-full bg-muted/40 hover:bg-muted/70 p-1.5 transition-all duration-200 ease-spring focus:outline-none focus:ring-2 focus:ring-ring/30 focus:ring-offset-2 disabled:pointer-events-none text-muted-foreground/60 hover:text-foreground">
+      <DialogPrimitive.Close className="absolute right-5 top-5 rounded-full bg-muted/40 hover:bg-muted/70 p-1.5 transition-all duration-200 ease-spring focus:outline-none focus:ring-2 focus:ring-ring/30 focus:ring-offset-2 disabled:pointer-events-none text-muted-foreground hover:text-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -23,7 +23,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-black/20 backdrop-blur-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-50 bg-black/25 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className,
     )}
     {...props}
@@ -44,13 +44,13 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid max-w-svw translate-x-[-50%] translate-y-[-50%] glass-panel p-6 shadow-glass duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed left-[50%] top-[50%] z-50 grid max-w-svw translate-x-[-50%] translate-y-[-50%] bg-popover border border-border p-6 shadow-elevated duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
         className,
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-md backdrop-blur-sm bg-muted/50 hover:bg-muted/80 border border-border/30 hover:border-border/60 p-1 transition-all duration-200 hover:scale-105 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none text-muted-foreground hover:text-foreground">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-md bg-muted/60 hover:bg-muted p-1 transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none text-muted-foreground hover:text-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -23,7 +23,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-black/25 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-50 bg-black/20 backdrop-blur-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className,
     )}
     {...props}
@@ -44,13 +44,13 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid max-w-svw translate-x-[-50%] translate-y-[-50%] bg-popover border border-border p-6 shadow-elevated duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed left-[50%] top-[50%] z-50 grid max-w-svw translate-x-[-50%] translate-y-[-50%] bg-popover/95 backdrop-blur-xl p-8 shadow-elevated duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-2xl',
         className,
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-md bg-muted/60 hover:bg-muted p-1 transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none text-muted-foreground hover:text-foreground">
+      <DialogPrimitive.Close className="absolute right-5 top-5 rounded-full bg-muted/40 hover:bg-muted/70 p-1.5 transition-all duration-200 ease-spring focus:outline-none focus:ring-2 focus:ring-ring/30 focus:ring-offset-2 disabled:pointer-events-none text-muted-foreground/60 hover:text-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -12,7 +12,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground transition-colors duration-150 hover:border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          'flex h-10 w-full rounded-xl bg-muted/40 px-3.5 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground/50 transition-all duration-200 ease-spring hover:bg-muted/60 focus-visible:outline-none focus-visible:bg-background focus-visible:ring-2 focus-visible:ring-ring/20 focus-visible:shadow-subtle disabled:cursor-not-allowed disabled:opacity-50',
           className,
         )}
         ref={ref}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -12,7 +12,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-md border border-input bg-background/50 backdrop-blur-sm px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground transition-all duration-200 hover:bg-background/70 hover:border-input/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:bg-background focus-visible:border-ring disabled:cursor-not-allowed disabled:opacity-50 shadow-sm',
+          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground transition-colors duration-150 hover:border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
           className,
         )}
         ref={ref}

--- a/src/index.css
+++ b/src/index.css
@@ -18,7 +18,7 @@
 
 @layer base {
   :root {
-    /* Modern clean light theme - YouTube/Material inspired */
+    /* Clean light theme */
     --background: 0 0% 100%;
     --foreground: 0 0% 9%;
 
@@ -49,7 +49,7 @@
 
     --ring: 32 95% 52% / 0.3;
 
-    --radius: 0.75rem;
+    --radius: 0.625rem;
 
     /* Status colors - semantic feedback colors */
     --success: 142 76% 36%;
@@ -75,59 +75,59 @@
   }
 
   .dark {
-    /* Arc Browser inspired dark theme with glassmorphism */
-    --background: 220 27% 8% / 0.05;
-    --foreground: 220 15% 85%;
+    /* Refined dark theme — less saturated, more confident */
+    --background: 220 18% 9%;
+    --foreground: 220 10% 88%;
 
-    --muted: 220 27% 12% / 0.4;
-    --muted-foreground: 220 10% 65%; /* Increased contrast from 60% */
+    --muted: 220 14% 14%;
+    --muted-foreground: 220 8% 62%;
 
-    --accent: 220 27% 18% / 0.6;
-    --accent-foreground: 220 15% 85%;
+    --accent: 220 14% 17%;
+    --accent-foreground: 220 10% 88%;
 
-    --popover: 220 27% 8% / 0.95;
-    --popover-foreground: 220 15% 85%;
+    --popover: 220 18% 10%;
+    --popover-foreground: 220 10% 88%;
 
-    --border: 220 27% 20% / 0.3;
-    --input: 220 27% 25% / 0.5;
+    --border: 220 14% 20% / 0.5;
+    --input: 220 14% 18%;
 
-    --card: 220 27% 12% / 0.7;
-    --card-foreground: 220 15% 85%;
+    --card: 220 16% 13%;
+    --card-foreground: 220 10% 88%;
 
-    --primary: 32 95% 55%;
-    --primary-foreground: 220 27% 8%;
+    --primary: 32 90% 55%;
+    --primary-foreground: 220 18% 9%;
 
-    --secondary: 220 27% 16% / 0.8;
-    --secondary-foreground: 220 15% 85%;
+    --secondary: 220 14% 16%;
+    --secondary-foreground: 220 10% 88%;
 
-    --destructive: 0 75% 55%;
+    --destructive: 0 70% 55%;
     --destructive-foreground: 210 40% 98%;
 
-    --ring: 32 95% 55% / 0.3;
+    --ring: 32 90% 55% / 0.25;
 
-    --radius: 0.75rem;
+    --radius: 0.625rem;
 
-    /* Status colors - dark mode variants */
-    --success: 142 70% 45%;
-    --success-foreground: 142 70% 10%;
-    --warning: 38 88% 55%;
-    --warning-foreground: 38 88% 10%;
-    --info: 200 90% 50%;
-    --info-foreground: 200 90% 10%;
+    /* Status colors — dark mode */
+    --success: 142 60% 45%;
+    --success-foreground: 142 60% 10%;
+    --warning: 38 80% 55%;
+    --warning-foreground: 38 80% 10%;
+    --info: 200 80% 50%;
+    --info-foreground: 200 80% 10%;
 
-    /* Surface hierarchy - dark mode */
-    --surface-elevated: 220 27% 14% / 0.9;
-    --surface-sunken: 220 27% 6% / 0.6;
+    /* Surface hierarchy */
+    --surface-elevated: 220 16% 15%;
+    --surface-sunken: 220 18% 7%;
 
-    /* Dark mode subtle gradient */
-    --gradient-start: 220 27% 10%;
-    --gradient-middle: 225 24% 8%;
-    --gradient-end: 230 20% 6%;
+    /* Subtle gradient */
+    --gradient-start: 220 18% 10%;
+    --gradient-middle: 222 16% 9%;
+    --gradient-end: 224 14% 7%;
 
-    /* Dark glass effect */
-    --glass-bg: 220 27% 12% / 0.1;
-    --glass-border: 220 27% 25% / 0.2;
-    --glass-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+    /* Glass — subtle, not flashy */
+    --glass-bg: 220 16% 12% / 0.6;
+    --glass-border: 220 14% 22% / 0.3;
+    --glass-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
   }
 }
 
@@ -147,50 +147,11 @@
     font-feature-settings:
       'rlig' 1,
       'calt' 1;
-    background: transparent;
-    backdrop-filter: blur(20px);
-    -webkit-backdrop-filter: blur(20px);
+    background: hsl(var(--background));
   }
   #root {
     height: 100vh;
     overflow: hidden;
-  }
-
-  /* Glassmorphism background with gradient overlay */
-  body::before {
-    content: '';
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: linear-gradient(
-      135deg,
-      hsl(var(--gradient-start)) 0%,
-      hsl(var(--gradient-middle)) 50%,
-      hsl(var(--gradient-end)) 100%
-    );
-    z-index: -2;
-  }
-
-  body::after {
-    content: '';
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: hsl(var(--glass-bg));
-    backdrop-filter: blur(20px);
-    -webkit-backdrop-filter: blur(20px);
-    z-index: -1;
-  }
-
-  /* Light mode: cleaner, less glass effect */
-  :root:not(.dark) body::after {
-    background: transparent;
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
   }
 
   @font-face {
@@ -198,28 +159,29 @@
     src: url('assets/NotoSansCJKjp-Regular.ttf') format('truetype');
   }
 
-  /* Webkit browsers (Chrome, Safari, etc) */
+  /* Scrollbar — thin and unobtrusive */
   ::-webkit-scrollbar {
-    width: 10px;
-    height: 10px;
+    width: 6px;
+    height: 6px;
   }
 
   ::-webkit-scrollbar-track {
-    @apply bg-gray-100 dark:bg-gray-900;
+    background: transparent;
   }
 
   ::-webkit-scrollbar-thumb {
-    @apply bg-gray-300 dark:bg-gray-700 rounded-full border-2 border-solid border-transparent bg-clip-padding hover:bg-gray-400 dark:hover:bg-gray-600 transition-colors;
+    background: hsl(var(--border));
+    border-radius: 3px;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background: hsl(var(--muted-foreground) / 0.4);
   }
 
   /* Firefox */
   * {
     scrollbar-width: thin;
-    scrollbar-color: var(--color-gray-300) var(--color-gray-100);
-  }
-
-  .dark * {
-    scrollbar-color: var(--color-gray-700) var(--color-gray-900);
+    scrollbar-color: hsl(var(--border)) transparent;
   }
 
   /* Hide scrollbar for Chrome, Safari and Opera when not hovering */
@@ -252,122 +214,64 @@
   }
 }
 
-/* Modal specific scrollbar styles */
-.modal-content::-webkit-scrollbar {
-  width: 8px;
-}
+/* Modal scrollbar inherits global thin style */
 
-.modal-content::-webkit-scrollbar-track {
-  @apply bg-transparent;
-}
-
-.modal-content::-webkit-scrollbar-thumb {
-  @apply bg-gray-300/80 dark:bg-gray-700/80 rounded-full hover:bg-gray-400 dark:hover:bg-gray-600;
-}
-
-/* Glassmorphism utility classes */
+/* Surface utility classes — clean, minimal depth */
 @layer utilities {
   .glass {
     background: hsl(var(--glass-bg));
-    backdrop-filter: blur(16px);
-    -webkit-backdrop-filter: blur(16px);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
     border: 1px solid hsl(var(--glass-border));
     box-shadow: var(--glass-shadow);
   }
 
   .glass-panel {
     background: hsl(var(--card));
-    backdrop-filter: blur(16px);
-    -webkit-backdrop-filter: blur(16px);
-    box-shadow:
-      0 2px 8px rgba(0, 0, 0, 0.08),
-      inset 0 1px 0 rgba(255, 255, 255, 0.03);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
   }
 
   .glass-card {
     background: hsl(var(--card));
-    backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px);
     border: 1px solid hsl(var(--border));
-    box-shadow:
-      0 2px 8px rgba(0, 0, 0, 0.08),
-      inset 0 1px 0 rgba(255, 255, 255, 0.03);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
   }
 
   .glass-button {
-    background: hsl(var(--primary) / 0.8);
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
-    border: 1px solid hsl(var(--primary) / 0.3);
-    transition: all 0.2s ease;
+    background: hsl(var(--primary));
+    transition: all 0.15s ease;
   }
 
   .glass-button:hover {
-    background: hsl(var(--primary) / 0.9);
-    transform: translateY(-1px);
-    box-shadow: 0 4px 12px rgba(247, 148, 29, 0.2);
+    background: hsl(var(--primary) / 0.88);
+    box-shadow: 0 2px 8px hsl(var(--primary) / 0.2);
   }
 
   .glass-input {
     background: hsl(var(--input));
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
     border: 1px solid hsl(var(--border));
   }
 
   .glass-input:focus {
-    background: hsl(var(--input) / 0.8);
-    border: 1px solid hsl(var(--ring));
-    box-shadow: 0 0 0 2px hsl(var(--ring) / 0.2);
+    border-color: hsl(var(--ring));
+    box-shadow: 0 0 0 2px hsl(var(--ring) / 0.15);
   }
 
-  /* Minimal title bar style */
   .minimal-header {
-    background: hsl(var(--background) / 0.02);
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
-    border-bottom: 1px solid hsl(var(--border) / 0.1);
-  }
-
-  /* Light mode: reduce glass effects for cleaner look */
-  :root:not(.dark) .glass {
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
-  }
-
-  :root:not(.dark) .glass-panel {
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
-  }
-
-  :root:not(.dark) .glass-card {
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
-  }
-
-  :root:not(.dark) .glass-button {
-    background: hsl(var(--primary));
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
-    border: none;
-  }
-
-  :root:not(.dark) .glass-button:hover {
-    background: hsl(var(--primary) / 0.9);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
-  }
-
-  :root:not(.dark) .glass-input {
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
-  }
-
-  :root:not(.dark) .minimal-header {
     background: hsl(var(--background));
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
     border-bottom: 1px solid hsl(var(--border));
+  }
+
+  /* Dark mode: add subtle depth */
+  .dark .glass-panel {
+    box-shadow:
+      0 1px 3px rgba(0, 0, 0, 0.12),
+      inset 0 1px 0 rgba(255, 255, 255, 0.02);
+  }
+
+  .dark .glass-card {
+    box-shadow:
+      0 1px 3px rgba(0, 0, 0, 0.12),
+      inset 0 1px 0 rgba(255, 255, 255, 0.02);
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -47,7 +47,7 @@
     --destructive: 0 84% 60%;
     --destructive-foreground: 0 0% 100%;
 
-    --ring: 32 95% 52% / 0.3;
+    --ring: 32 95% 52%;
 
     --radius: 0.625rem;
 
@@ -103,7 +103,7 @@
     --destructive: 0 70% 55%;
     --destructive-foreground: 210 40% 98%;
 
-    --ring: 32 90% 55% / 0.25;
+    --ring: 32 90% 55%;
 
     --radius: 0.625rem;
 
@@ -239,7 +239,9 @@
 
   .glass-button {
     background: hsl(var(--primary));
-    transition: all 0.15s ease;
+    transition:
+      background-color 0.15s ease,
+      box-shadow 0.15s ease;
   }
 
   .glass-button:hover {
@@ -253,7 +255,7 @@
   }
 
   .glass-input:focus {
-    border-color: hsl(var(--ring));
+    border-color: hsl(var(--ring) / 0.3);
     box-shadow: 0 0 0 2px hsl(var(--ring) / 0.15);
   }
 

--- a/src/index.css
+++ b/src/index.css
@@ -18,116 +18,117 @@
 
 @layer base {
   :root {
-    /* Clean light theme */
-    --background: 0 0% 100%;
-    --foreground: 0 0% 9%;
+    /* Light theme — crisp, spacious, almost-white with subtle warmth */
+    --background: 0 0% 99%;
+    --foreground: 0 0% 8%;
 
-    --muted: 0 0% 96%;
-    --muted-foreground: 0 0% 45%;
+    --muted: 210 6% 95%;
+    --muted-foreground: 0 0% 42%;
 
     --popover: 0 0% 100%;
-    --popover-foreground: 0 0% 9%;
+    --popover-foreground: 0 0% 8%;
 
-    --border: 0 0% 90%;
-    --input: 0 0% 93%;
+    --border: 0 0% 92%;
+    --input: 210 4% 95%;
 
     --card: 0 0% 100%;
-    --card-foreground: 0 0% 9%;
+    --card-foreground: 0 0% 8%;
 
-    --primary: 32 95% 52%;
+    --primary: 28 100% 50%;
     --primary-foreground: 0 0% 100%;
 
-    --secondary-muted: 0 0% 96%;
-    --secondary: 0 0% 96%;
-    --secondary-foreground: 0 0% 9%;
+    --secondary-muted: 210 6% 95%;
+    --secondary: 210 6% 95%;
+    --secondary-foreground: 0 0% 8%;
 
-    --accent: 30 6% 96%;
-    --accent-foreground: 32 80% 42%;
+    --accent: 210 6% 96%;
+    --accent-foreground: 28 90% 38%;
 
     --destructive: 0 84% 60%;
     --destructive-foreground: 0 0% 100%;
 
-    --ring: 32 95% 52%;
+    --ring: 28 100% 50%;
 
-    --radius: 0.625rem;
+    --radius: 0.75rem;
 
-    /* Status colors - semantic feedback colors */
-    --success: 142 76% 36%;
+    /* Status colors */
+    --success: 152 69% 36%;
     --success-foreground: 0 0% 100%;
     --warning: 38 92% 50%;
     --warning-foreground: 38 92% 20%;
-    --info: 200 98% 39%;
+    --info: 210 92% 44%;
     --info-foreground: 0 0% 100%;
 
     /* Surface hierarchy */
     --surface-elevated: 0 0% 100%;
-    --surface-sunken: 0 0% 97%;
+    --surface-sunken: 210 6% 97%;
 
-    /* Clean neutral gradient - no blue tint */
-    --gradient-start: 0 0% 98%;
-    --gradient-middle: 0 0% 97%;
-    --gradient-end: 0 0% 96%;
+    /* Near-neutral gradient */
+    --gradient-start: 0 0% 99%;
+    --gradient-middle: 210 3% 98%;
+    --gradient-end: 210 4% 97%;
 
-    /* Glass effect - more opaque for light mode */
-    --glass-bg: 0 0% 100% / 0.9;
-    --glass-border: 0 0% 88%;
-    --glass-shadow: 0 4px 16px rgba(0, 0, 0, 0.06);
+    /* Glass — barely there */
+    --glass-bg: 0 0% 100% / 0.88;
+    --glass-border: 0 0% 90%;
+    --glass-shadow: 0 4px 16px rgba(0, 0, 0, 0.04);
   }
 
   .dark {
-    /* Refined dark theme — less saturated, more confident */
-    --background: 220 18% 9%;
-    --foreground: 220 10% 88%;
+    /* Dark theme — deep, confident, Arc/Dia-inspired
+       Hue 240-250 gives a rich indigo-navy, not muddy gray */
+    --background: 240 12% 8%;
+    --foreground: 0 0% 93%;
 
-    --muted: 220 14% 14%;
-    --muted-foreground: 220 8% 62%;
+    --muted: 240 10% 13%;
+    --muted-foreground: 240 5% 55%;
 
-    --accent: 220 14% 17%;
-    --accent-foreground: 220 10% 88%;
+    --accent: 240 10% 16%;
+    --accent-foreground: 0 0% 93%;
 
-    --popover: 220 18% 10%;
-    --popover-foreground: 220 10% 88%;
+    --popover: 240 12% 10%;
+    --popover-foreground: 0 0% 93%;
 
-    --border: 220 14% 20% / 0.5;
-    --input: 220 14% 18%;
+    --border: 240 8% 16%;
+    --input: 240 10% 14%;
 
-    --card: 220 16% 13%;
-    --card-foreground: 220 10% 88%;
+    --card: 240 10% 11%;
+    --card-foreground: 0 0% 93%;
 
-    --primary: 32 90% 55%;
-    --primary-foreground: 220 18% 9%;
+    --primary: 28 100% 54%;
+    --primary-foreground: 240 12% 8%;
 
-    --secondary: 220 14% 16%;
-    --secondary-foreground: 220 10% 88%;
+    --secondary: 240 10% 15%;
+    --secondary-foreground: 0 0% 93%;
 
-    --destructive: 0 70% 55%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive: 0 72% 55%;
+    --destructive-foreground: 0 0% 98%;
 
-    --ring: 32 90% 55%;
+    --ring: 28 100% 54%;
 
-    --radius: 0.625rem;
+    --radius: 0.75rem;
 
     /* Status colors — dark mode */
-    --success: 142 60% 45%;
-    --success-foreground: 142 60% 10%;
+    --success: 152 55% 45%;
+    --success-foreground: 152 55% 10%;
     --warning: 38 80% 55%;
     --warning-foreground: 38 80% 10%;
-    --info: 200 80% 50%;
-    --info-foreground: 200 80% 10%;
+    --info: 210 80% 55%;
+    --info-foreground: 210 80% 10%;
 
-    /* Surface hierarchy */
-    --surface-elevated: 220 16% 15%;
-    --surface-sunken: 220 18% 7%;
+    /* Surface hierarchy — clear separation */
+    --surface-elevated: 240 10% 15%;
+    --surface-sunken: 240 12% 6%;
 
-    /* Subtle gradient */
-    --gradient-start: 220 18% 10%;
-    --gradient-middle: 222 16% 9%;
-    --gradient-end: 224 14% 7%;
+    /* Rich indigo gradient — gives true depth */
+    --gradient-start: 240 12% 10%;
+    --gradient-middle: 242 10% 8%;
+    --gradient-end: 244 8% 6%;
 
-    /* Glass — subtle, not flashy */
-    --glass-bg: 220 16% 12% / 0.6;
-    --glass-border: 220 14% 22% / 0.3;
-    --glass-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
+    /* Glass — deep and translucent */
+    --glass-bg: 240 10% 12% / 0.75;
+    --glass-border: 240 8% 22% / 0.4;
+    --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
   }
 }
 
@@ -147,7 +148,13 @@
     font-feature-settings:
       'rlig' 1,
       'calt' 1;
-    background: hsl(var(--background));
+    /* Subtle gradient background — gives depth without blur performance cost */
+    background: linear-gradient(
+      160deg,
+      hsl(var(--gradient-start)) 0%,
+      hsl(var(--gradient-middle)) 50%,
+      hsl(var(--gradient-end)) 100%
+    );
   }
   #root {
     height: 100vh;
@@ -159,10 +166,10 @@
     src: url('assets/NotoSansCJKjp-Regular.ttf') format('truetype');
   }
 
-  /* Scrollbar — thin and unobtrusive */
+  /* Scrollbar — whisper-thin, appears only on hover */
   ::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
+    width: 5px;
+    height: 5px;
   }
 
   ::-webkit-scrollbar-track {
@@ -170,18 +177,18 @@
   }
 
   ::-webkit-scrollbar-thumb {
-    background: hsl(var(--border));
-    border-radius: 3px;
+    background: hsl(var(--muted-foreground) / 0.15);
+    border-radius: 999px;
   }
 
   ::-webkit-scrollbar-thumb:hover {
-    background: hsl(var(--muted-foreground) / 0.4);
+    background: hsl(var(--muted-foreground) / 0.3);
   }
 
   /* Firefox */
   * {
     scrollbar-width: thin;
-    scrollbar-color: hsl(var(--border)) transparent;
+    scrollbar-color: hsl(var(--muted-foreground) / 0.15) transparent;
   }
 
   /* Hide scrollbar for Chrome, Safari and Opera when not hovering */
@@ -191,8 +198,8 @@
 
   /* Hide scrollbar for IE, Edge and Firefox */
   .scrollbar-hide {
-    -ms-overflow-style: none; /* IE and Edge */
-    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none;
+    scrollbar-width: none;
   }
 
   /* Show scrollbar on hover */
@@ -214,66 +221,78 @@
   }
 }
 
-/* Modal scrollbar inherits global thin style */
-
-/* Surface utility classes — clean, minimal depth */
+/* Surface utility classes — Arc/Dia-inspired elevation system */
 @layer utilities {
   .glass {
     background: hsl(var(--glass-bg));
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(16px) saturate(120%);
+    -webkit-backdrop-filter: blur(16px) saturate(120%);
     border: 1px solid hsl(var(--glass-border));
     box-shadow: var(--glass-shadow);
   }
 
   .glass-panel {
     background: hsl(var(--card));
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+    box-shadow:
+      0 1px 2px rgba(0, 0, 0, 0.03),
+      0 4px 16px rgba(0, 0, 0, 0.02);
   }
 
   .glass-card {
     background: hsl(var(--card));
-    border: 1px solid hsl(var(--border));
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+    box-shadow:
+      0 1px 2px rgba(0, 0, 0, 0.03),
+      0 4px 16px rgba(0, 0, 0, 0.02);
   }
 
   .glass-button {
     background: hsl(var(--primary));
     transition:
-      background-color 0.15s ease,
-      box-shadow 0.15s ease;
+      background-color 0.2s cubic-bezier(0.22, 1, 0.36, 1),
+      box-shadow 0.2s cubic-bezier(0.22, 1, 0.36, 1),
+      transform 0.2s cubic-bezier(0.22, 1, 0.36, 1);
   }
 
   .glass-button:hover {
-    background: hsl(var(--primary) / 0.88);
-    box-shadow: 0 2px 8px hsl(var(--primary) / 0.2);
+    background: hsl(var(--primary) / 0.92);
+    box-shadow: 0 4px 20px hsl(var(--primary) / 0.25);
+    transform: translateY(-0.5px);
+  }
+
+  .glass-button:active {
+    transform: translateY(0.5px);
+    box-shadow: 0 2px 8px hsl(var(--primary) / 0.15);
   }
 
   .glass-input {
     background: hsl(var(--input));
-    border: 1px solid hsl(var(--border));
+    border: 1.5px solid transparent;
+    transition:
+      border-color 0.2s cubic-bezier(0.22, 1, 0.36, 1),
+      box-shadow 0.2s cubic-bezier(0.22, 1, 0.36, 1);
   }
 
   .glass-input:focus {
-    border-color: hsl(var(--ring) / 0.3);
-    box-shadow: 0 0 0 2px hsl(var(--ring) / 0.15);
+    border-color: hsl(var(--ring) / 0.4);
+    box-shadow: 0 0 0 3px hsl(var(--ring) / 0.1);
   }
 
   .minimal-header {
-    background: hsl(var(--background));
-    border-bottom: 1px solid hsl(var(--border));
+    background: hsl(var(--background) / 0.8);
+    backdrop-filter: blur(12px) saturate(120%);
+    -webkit-backdrop-filter: blur(12px) saturate(120%);
   }
 
-  /* Dark mode: add subtle depth */
+  /* Dark mode: deeper shadows, subtle inner glow */
   .dark .glass-panel {
     box-shadow:
-      0 1px 3px rgba(0, 0, 0, 0.12),
-      inset 0 1px 0 rgba(255, 255, 255, 0.02);
+      0 2px 8px rgba(0, 0, 0, 0.16),
+      0 0 1px rgba(255, 255, 255, 0.04) inset;
   }
 
   .dark .glass-card {
     box-shadow:
-      0 1px 3px rgba(0, 0, 0, 0.12),
-      inset 0 1px 0 rgba(255, 255, 255, 0.02);
+      0 2px 8px rgba(0, 0, 0, 0.16),
+      0 0 1px rgba(255, 255, 255, 0.04) inset;
   }
 }

--- a/src/v2/App.tsx
+++ b/src/v2/App.tsx
@@ -553,9 +553,9 @@ const Contents = memo(() => {
 
             {/* プログレスバー */}
             <div className="mt-6 w-full max-w-xs mx-auto">
-              <div className="h-1 bg-muted rounded-full overflow-hidden">
+              <div className="h-0.5 bg-muted/60 rounded-full overflow-hidden">
                 <div
-                  className="h-full bg-primary transition-all duration-300 ease-out rounded-full"
+                  className="h-full bg-primary transition-all duration-500 ease-spring rounded-full"
                   style={{
                     width: `${Math.min(Math.max(progressPercent, 5), 100)}%`,
                   }}

--- a/src/v2/App.tsx
+++ b/src/v2/App.tsx
@@ -361,25 +361,25 @@ const Contents = memo(() => {
           {match(errorDisplayType)
             .with('setup', () => (
               <div className="w-full max-w-2xl mx-auto p-6">
-                <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">
+                <h2 className="text-xl font-semibold text-foreground mb-2">
                   初期セットアップ
                 </h2>
-                <p className="text-gray-600 dark:text-gray-400 mb-6">
+                <p className="text-muted-foreground mb-6">
                   VRChatのログフォルダと写真フォルダを設定して、アプリケーションを使用する準備をしましょう。
                 </p>
-                <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+                <div className="bg-card rounded-lg shadow-subtle p-6 border border-border">
                   <div className="space-y-4">
                     <div className="flex items-start space-x-3">
                       <div className="flex-shrink-0">
-                        <div className="w-8 h-8 rounded-full bg-primary/10 dark:bg-primary/20 flex items-center justify-center">
+                        <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center">
                           <span className="text-primary">1</span>
                         </div>
                       </div>
                       <div>
-                        <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                        <h3 className="text-sm font-medium text-foreground">
                           フォルダを設定
                         </h3>
-                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                        <p className="text-sm text-muted-foreground">
                           以下の設定画面からVRChatのログフォルダと写真フォルダを選択してください。
                         </p>
                       </div>
@@ -387,15 +387,15 @@ const Contents = memo(() => {
                     <PathSettings showRefreshAll={false} />
                     <div className="flex items-start space-x-3">
                       <div className="flex-shrink-0">
-                        <div className="w-8 h-8 rounded-full bg-primary/10 dark:bg-primary/20 flex items-center justify-center">
+                        <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center">
                           <span className="text-primary">2</span>
                         </div>
                       </div>
                       <div>
-                        <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                        <h3 className="text-sm font-medium text-foreground">
                           設定を確認
                         </h3>
-                        <p className="text-sm text-gray-500 dark:text-gray-400">
+                        <p className="text-sm text-muted-foreground">
                           フォルダを設定したら、下のボタンをクリックして設定を確認します。
                         </p>
                       </div>
@@ -415,14 +415,14 @@ const Contents = memo(() => {
             ))
             .otherwise(() => (
               <div className="text-center p-4 max-w-md mx-auto">
-                <h2 className="text-xl font-semibold text-red-600 dark:text-red-400">
+                <h2 className="text-xl font-semibold text-destructive">
                   {match(errorDisplayType)
                     .with('permission', () => 'アクセス許可エラー')
                     .with('database', () => 'データベースエラー')
                     .with('network', () => 'ネットワークエラー')
                     .otherwise(() => 'アプリケーションエラー')}
                 </h2>
-                <p className="mt-2 text-gray-600 dark:text-gray-400">
+                <p className="mt-2 text-muted-foreground">
                   {match(errorDisplayType)
                     .with(
                       'permission',
@@ -453,10 +453,10 @@ const Contents = memo(() => {
                 </p>
                 {errorInfo && (
                   <details className="mt-4 text-left" open>
-                    <summary className="cursor-pointer text-sm text-gray-500">
+                    <summary className="cursor-pointer text-sm text-muted-foreground">
                       エラー詳細
                     </summary>
-                    <pre className="mt-2 p-2 bg-gray-100 dark:bg-gray-800 rounded text-xs overflow-auto">
+                    <pre className="mt-2 p-2 bg-muted rounded text-xs overflow-auto">
                       {errorInfo.userMessage}
                     </pre>
                   </details>
@@ -482,7 +482,7 @@ const Contents = memo(() => {
 
     return (
       <div
-        className="h-screen flex flex-col overflow-hidden bg-[#f9f9fa] dark:bg-[#1c1c1e]"
+        className="h-screen flex flex-col overflow-hidden bg-background"
         data-testid="loading-screen"
       >
         <AppHeader showGalleryControls={false} />
@@ -492,7 +492,7 @@ const Contents = memo(() => {
             <div className="relative mb-8">
               <div className="mx-auto w-20 h-20 relative">
                 {/* ベースの円 */}
-                <div className="absolute inset-0 rounded-full bg-gray-100 dark:bg-gray-800" />
+                <div className="absolute inset-0 rounded-full bg-muted" />
 
                 {/* プログレス - 実際の進捗を反映 */}
                 <svg
@@ -509,7 +509,7 @@ const Contents = memo(() => {
                     fill="none"
                     stroke="currentColor"
                     strokeWidth="3"
-                    className="text-gray-200 dark:text-gray-700"
+                    className="text-border"
                   />
                   {/* 進捗の円 */}
                   <circle
@@ -529,7 +529,7 @@ const Contents = memo(() => {
                 {/* 中央のパーセント表示 */}
                 <div className="absolute inset-0 flex items-center justify-center">
                   <span
-                    className="text-sm font-medium text-gray-600 dark:text-gray-400"
+                    className="text-sm font-medium text-muted-foreground"
                     data-testid="progress-percent"
                   >
                     {progressPercent > 0 ? `${progressPercent}%` : ''}
@@ -540,11 +540,11 @@ const Contents = memo(() => {
 
             {/* テキストエリア - タイポグラフィ */}
             <div className="space-y-3">
-              <h2 className="text-lg font-medium text-gray-900 dark:text-gray-100 tracking-tight">
+              <h2 className="text-lg font-medium text-foreground tracking-tight">
                 データを読み込み中...
               </h2>
               <p
-                className="text-sm text-gray-500 dark:text-gray-500 min-h-[1.5em]"
+                className="text-sm text-muted-foreground min-h-[1.5em]"
                 data-testid="progress-message"
               >
                 {displayMessage}
@@ -553,7 +553,7 @@ const Contents = memo(() => {
 
             {/* プログレスバー */}
             <div className="mt-6 w-full max-w-xs mx-auto">
-              <div className="h-1.5 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+              <div className="h-1 bg-muted rounded-full overflow-hidden">
                 <div
                   className="h-full bg-primary transition-all duration-300 ease-out rounded-full"
                   style={{
@@ -568,15 +568,15 @@ const Contents = memo(() => {
             {/* シンプルなドットインジケーター */}
             <div className="mt-6 flex justify-center items-center space-x-1.5">
               <div
-                className="w-1.5 h-1.5 bg-gray-300 dark:bg-gray-600 rounded-full animate-dot-fade"
+                className="w-1 h-1 bg-muted-foreground/30 rounded-full animate-dot-fade"
                 style={{ animationDelay: '0ms' }}
               />
               <div
-                className="w-1.5 h-1.5 bg-gray-300 dark:bg-gray-600 rounded-full animate-dot-fade"
+                className="w-1 h-1 bg-muted-foreground/30 rounded-full animate-dot-fade"
                 style={{ animationDelay: '200ms' }}
               />
               <div
-                className="w-1.5 h-1.5 bg-gray-300 dark:bg-gray-600 rounded-full animate-dot-fade"
+                className="w-1 h-1 bg-muted-foreground/30 rounded-full animate-dot-fade"
                 style={{ animationDelay: '400ms' }}
               />
             </div>

--- a/src/v2/components/AppHeader.tsx
+++ b/src/v2/components/AppHeader.tsx
@@ -109,7 +109,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
 
   return (
     <div
-      className="flex h-11 items-center justify-between px-2 select-none border-b border-border"
+      className="flex h-11 items-center justify-between px-3 select-none minimal-header"
       style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
       onDoubleClick={handleMaximize}
     >
@@ -201,7 +201,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           variant="ghost"
           size="sm"
           onClick={handleMinimize}
-          className="h-7 w-7 p-0 text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted transition-colors duration-150"
+          className="h-7 w-7 p-0 text-muted-foreground/40 hover:text-muted-foreground hover:bg-muted/60 rounded-full transition-all duration-200 ease-spring"
         >
           <Minus className={ICON_SIZE.sm.class} />
         </Button>
@@ -209,7 +209,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           variant="ghost"
           size="sm"
           onClick={handleMaximize}
-          className="h-7 w-7 p-0 text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted transition-colors duration-150"
+          className="h-7 w-7 p-0 text-muted-foreground/40 hover:text-muted-foreground hover:bg-muted/60 rounded-full transition-all duration-200 ease-spring"
         >
           <Square className={ICON_SIZE.sm.class} />
         </Button>
@@ -217,7 +217,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           variant="ghost"
           size="sm"
           onClick={handleClose}
-          className="h-7 w-7 p-0 text-muted-foreground/50 hover:text-destructive hover:bg-destructive/10 transition-colors duration-150"
+          className="h-7 w-7 p-0 text-muted-foreground/40 hover:text-destructive hover:bg-destructive/8 rounded-full transition-all duration-200 ease-spring"
         >
           <X className={ICON_SIZE.sm.class} />
         </Button>

--- a/src/v2/components/AppHeader.tsx
+++ b/src/v2/components/AppHeader.tsx
@@ -201,7 +201,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           variant="ghost"
           size="sm"
           onClick={handleMinimize}
-          className="h-7 w-7 p-0 text-muted-foreground/40 hover:text-muted-foreground hover:bg-muted/60 rounded-full transition-all duration-200 ease-spring"
+          className="h-7 w-7 p-0 text-muted-foreground/60 hover:text-muted-foreground hover:bg-muted/60 rounded-full transition-all duration-200 ease-spring"
         >
           <Minus className={ICON_SIZE.sm.class} />
         </Button>
@@ -209,7 +209,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           variant="ghost"
           size="sm"
           onClick={handleMaximize}
-          className="h-7 w-7 p-0 text-muted-foreground/40 hover:text-muted-foreground hover:bg-muted/60 rounded-full transition-all duration-200 ease-spring"
+          className="h-7 w-7 p-0 text-muted-foreground/60 hover:text-muted-foreground hover:bg-muted/60 rounded-full transition-all duration-200 ease-spring"
         >
           <Square className={ICON_SIZE.sm.class} />
         </Button>
@@ -217,7 +217,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           variant="ghost"
           size="sm"
           onClick={handleClose}
-          className="h-7 w-7 p-0 text-muted-foreground/40 hover:text-destructive hover:bg-destructive/8 rounded-full transition-all duration-200 ease-spring"
+          className="h-7 w-7 p-0 text-muted-foreground/60 hover:text-destructive hover:bg-destructive/8 rounded-full transition-all duration-200 ease-spring"
         >
           <X className={ICON_SIZE.sm.class} />
         </Button>

--- a/src/v2/components/AppHeader.tsx
+++ b/src/v2/components/AppHeader.tsx
@@ -191,7 +191,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
             variant="ghost"
             size="sm"
             onClick={() => quitAndInstall.mutate()}
-            className="h-7 w-7 p-0 hover:bg-success/15 text-success/70 hover:text-success transition-colors duration-150"
+            className="h-7 w-7 p-0 text-success/80 hover:text-success hover:bg-success/10 transition-colors duration-150"
             title="アップデートをインストール"
           >
             <Download className={ICON_SIZE.sm.class} />
@@ -201,7 +201,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           variant="ghost"
           size="sm"
           onClick={handleMinimize}
-          className="h-7 w-7 p-0 hover:bg-muted/40 text-muted-foreground/60 hover:text-muted-foreground transition-colors duration-150"
+          className="h-7 w-7 p-0 text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted transition-colors duration-150"
         >
           <Minus className={ICON_SIZE.sm.class} />
         </Button>
@@ -209,7 +209,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           variant="ghost"
           size="sm"
           onClick={handleMaximize}
-          className="h-7 w-7 p-0 hover:bg-muted/40 text-muted-foreground/60 hover:text-muted-foreground transition-colors duration-150"
+          className="h-7 w-7 p-0 text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted transition-colors duration-150"
         >
           <Square className={ICON_SIZE.sm.class} />
         </Button>
@@ -217,7 +217,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
           variant="ghost"
           size="sm"
           onClick={handleClose}
-          className="h-7 w-7 p-0 hover:bg-destructive/80 text-muted-foreground/60 hover:text-white transition-colors duration-150"
+          className="h-7 w-7 p-0 text-muted-foreground/50 hover:text-destructive hover:bg-destructive/10 transition-colors duration-150"
         >
           <X className={ICON_SIZE.sm.class} />
         </Button>

--- a/src/v2/components/LanguageSelector.tsx
+++ b/src/v2/components/LanguageSelector.tsx
@@ -34,7 +34,7 @@ const LanguageSelector = memo(() => {
                 : 'text-muted-foreground/60 hover:bg-muted/30 hover:text-foreground',
             )}
           >
-            <span className="text-[13px] font-medium">{label}</span>
+            <span className="text-sm font-medium">{label}</span>
           </button>
         ))}
       </div>

--- a/src/v2/components/LanguageSelector.tsx
+++ b/src/v2/components/LanguageSelector.tsx
@@ -31,7 +31,7 @@ const LanguageSelector = memo(() => {
             className={cn(
               'flex items-center justify-center p-3 rounded-lg border-2 transition-colors',
               language === value
-                ? 'border-primary bg-primary/10 dark:bg-primary/20'
+                ? 'border-primary bg-primary/10'
                 : 'border-border hover:border-primary/50',
             )}
           >

--- a/src/v2/components/LanguageSelector.tsx
+++ b/src/v2/components/LanguageSelector.tsx
@@ -3,7 +3,6 @@ import { memo } from 'react';
 
 import { cn } from '@/components/lib/utils';
 
-import { TEXT_COLOR, TYPOGRAPHY } from '../constants/ui';
 import { useI18n } from '../i18n/store';
 import type { Language } from '../i18n/types';
 import { SettingsSection } from './settings/common';
@@ -29,20 +28,13 @@ const LanguageSelector = memo(() => {
             type="button"
             onClick={() => setLanguage(value)}
             className={cn(
-              'flex items-center justify-center p-3 rounded-lg border-2 transition-colors',
+              'flex items-center justify-center py-4 px-6 rounded-xl transition-all duration-200 ease-spring',
               language === value
-                ? 'border-primary bg-primary/10'
-                : 'border-border hover:border-primary/50',
+                ? 'bg-muted/60 text-foreground shadow-subtle'
+                : 'text-muted-foreground/60 hover:bg-muted/30 hover:text-foreground',
             )}
           >
-            <span
-              className={cn(
-                TYPOGRAPHY.body.emphasis,
-                language === value ? 'text-primary' : TEXT_COLOR.secondary,
-              )}
-            >
-              {label}
-            </span>
+            <span className="text-[13px] font-medium">{label}</span>
           </button>
         ))}
       </div>

--- a/src/v2/components/LocationGroupHeader/index.tsx
+++ b/src/v2/components/LocationGroupHeader/index.tsx
@@ -228,23 +228,19 @@ export const LocationGroupHeader = ({
       className="w-full glass-panel rounded-t-lg overflow-hidden group/card"
     >
       <div className="relative h-24 overflow-hidden flex items-center justify-center">
-        <div className="absolute inset-0 bg-gradient-to-br from-white to-gray-50/90 dark:from-gray-800 dark:to-gray-900/80">
+        <div className="absolute inset-0 bg-muted">
           {details?.thumbnailImageUrl && isVisible && (
             <>
               <div
-                className="absolute inset-0 scale-110 transition-transform duration-700"
+                className="absolute inset-0 scale-105"
                 style={{
                   backgroundImage: `url(${details.thumbnailImageUrl})`,
                   backgroundSize: 'cover',
                   backgroundPosition: 'center',
-                  filter: 'blur(26px) saturate(120%) brightness(0.9)',
+                  filter: 'blur(24px) saturate(110%) brightness(0.95)',
                 }}
               />
-              <div className="absolute inset-0 bg-white/85 dark:bg-black/50 backdrop-blur-[1px] group-hover/card:backdrop-blur-[2px] transition-all duration-500" />
-              <div className="absolute inset-0">
-                <div className="absolute inset-0 bg-gradient-to-r from-white/70 to-white/50 dark:from-black/30 dark:to-black/10 mix-blend-overlay" />
-                <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_120%,rgba(255,255,255,0.7),rgba(255,255,255,0.4)_70%)] dark:bg-[radial-gradient(circle_at_50%_120%,rgba(0,0,0,0.4),rgba(0,0,0,0.2)_70%)]" />
-              </div>
+              <div className="absolute inset-0 bg-background/80 dark:bg-background/60" />
             </>
           )}
         </div>
@@ -268,11 +264,11 @@ export const LocationGroupHeader = ({
                 </div>
               ) : (
                 <div
-                  className="h-20 rounded-lg bg-gray-100 dark:bg-gray-800 flex items-center justify-center border border-gray-200 dark:border-gray-700/30"
+                  className="h-20 rounded-lg bg-muted flex items-center justify-center border border-border"
                   style={{ aspectRatio: '4/3' }}
                 >
                   <ImageIcon
-                    className={`${ICON_SIZE.lg.class} text-gray-300 dark:text-gray-600`}
+                    className={`${ICON_SIZE.lg.class} text-muted-foreground/30`}
                   />
                 </div>
               )}
@@ -282,10 +278,10 @@ export const LocationGroupHeader = ({
             <div className="flex-1 min-w-0 flex flex-col gap-2">
               {/* 1行目: ワールド名とアクション */}
               <div className="flex items-center justify-between">
-                <h3 className="text-lg font-bold flex items-center group/title text-gray-800 dark:text-white">
+                <h3 className="text-lg font-semibold flex items-center group/title text-foreground">
                   <button
                     type="button"
-                    className="hover:underline flex items-center transition-all duration-300 hover:text-primary-600 dark:hover:text-primary-300"
+                    className="hover:underline flex items-center transition-colors duration-150 hover:text-primary"
                     onClick={(e) => {
                       e.stopPropagation();
                       openWorldLink(worldLink);
@@ -303,7 +299,7 @@ export const LocationGroupHeader = ({
                   {worldInstanceId &&
                     shouldShowInstanceTypeBadge(worldInstanceId) && (
                       <div
-                        className={`flex items-center text-xs font-medium px-2.5 py-1 rounded-full backdrop-blur-sm border transition-all duration-300 ${getInstanceTypeColor(
+                        className={`flex items-center text-xs font-medium px-2 py-0.5 rounded-md border transition-colors duration-150 ${getInstanceTypeColor(
                           worldInstanceId,
                         )}`}
                       >
@@ -331,9 +327,9 @@ export const LocationGroupHeader = ({
                   <button
                     type="button"
                     onClick={openShareModal}
-                    className="flex items-center text-sm font-medium text-gray-800 dark:text-white backdrop-blur-sm bg-primary-500/10 hover:bg-primary-500/20 dark:bg-primary-500/30 dark:hover:bg-primary-500/40 px-3 py-1 rounded-full transition-all duration-300 border border-white/20 dark:border-white/10 hover:border-white/30 dark:hover:border-white/20"
+                    className="flex items-center text-sm font-medium text-foreground bg-muted hover:bg-muted/80 px-2.5 py-1 rounded-md transition-colors duration-150 border border-border"
                   >
-                    <Share2 className={`${ICON_SIZE.sm.class} mr-1.5`} />
+                    <Share2 className={`${ICON_SIZE.sm.class}`} />
                   </button>
                 </div>
               </div>
@@ -343,38 +339,32 @@ export const LocationGroupHeader = ({
                 {(() => {
                   if (isPlayersLoading || players === null) {
                     return (
-                      // ローディング中 or 未取得: スケルトン表示
-                      <div className="flex gap-2 items-center text-xs text-gray-800 dark:text-white backdrop-blur-sm bg-white/30 dark:bg-black/30 px-3 py-1 rounded-full border border-white/20 dark:border-gray-700/30 flex-1 min-w-0">
+                      <div className="flex gap-2 items-center text-xs text-foreground bg-muted/60 px-3 py-1 rounded-md border border-border flex-1 min-w-0">
                         <div className="flex items-center gap-1">
                           <Users
-                            className={`${ICON_SIZE.sm.class} text-primary-600 dark:text-primary-300 flex-shrink-0`}
+                            className={`${ICON_SIZE.sm.class} text-primary flex-shrink-0`}
                           />
-                          <div className="h-4 w-6 bg-gray-300/50 dark:bg-gray-600/50 rounded animate-pulse" />
+                          <div className="h-4 w-6 bg-muted rounded animate-pulse" />
                         </div>
-                        <div className="text-gray-500 dark:text-gray-400">
-                          |
-                        </div>
+                        <div className="text-muted-foreground/40">|</div>
                         <div className="flex-1 flex items-center gap-2">
-                          <div className="h-4 w-24 bg-gray-300/50 dark:bg-gray-600/50 rounded animate-pulse" />
-                          <div className="h-4 w-20 bg-gray-300/50 dark:bg-gray-600/50 rounded animate-pulse" />
-                          <div className="h-4 w-16 bg-gray-300/50 dark:bg-gray-600/50 rounded animate-pulse" />
+                          <div className="h-4 w-24 bg-muted rounded animate-pulse" />
+                          <div className="h-4 w-20 bg-muted rounded animate-pulse" />
+                          <div className="h-4 w-16 bg-muted rounded animate-pulse" />
                         </div>
                       </div>
                     );
                   }
                   if (players.length > 0) {
                     return (
-                      // プレイヤーあり（取得済み、データあり）: リスト表示
-                      <div className="flex gap-2 items-center text-xs text-gray-800 dark:text-white backdrop-blur-sm bg-white/30 hover:bg-white/40 dark:bg-black/30 dark:hover:bg-black/40 px-3 py-1 rounded-full transition-all duration-300 border border-white/20 dark:border-gray-700/30 hover:border-white/30 dark:hover:border-gray-700/40 group/players flex-1 min-w-0">
+                      <div className="flex gap-2 items-center text-xs text-foreground bg-muted/60 hover:bg-muted/80 px-3 py-1 rounded-md transition-colors duration-150 border border-border group/players flex-1 min-w-0">
                         <div className="flex items-center gap-1">
                           <Users
-                            className={`${ICON_SIZE.sm.class} text-primary-600 dark:text-primary-300 flex-shrink-0`}
+                            className={`${ICON_SIZE.sm.class} text-primary flex-shrink-0`}
                           />
                           <span>{players.length}</span>
                         </div>
-                        <div className="text-gray-500 dark:text-gray-400">
-                          |
-                        </div>
+                        <div className="text-muted-foreground/40">|</div>
                         <button
                           type="button"
                           ref={playerListContainerRef}
@@ -387,7 +377,7 @@ export const LocationGroupHeader = ({
                         >
                           <div className="flex items-center gap-2 w-full">
                             {isCopied ? (
-                              <span className="text-green-400 flex items-center gap-2">
+                              <span className="text-success flex items-center gap-2">
                                 <CheckIcon className={ICON_SIZE.sm.class} />
                                 {t('locationHeader.copied')}
                               </span>
@@ -405,17 +395,17 @@ export const LocationGroupHeader = ({
                                   position: 'fixed',
                                   visibility: isHovered ? 'visible' : 'hidden',
                                   opacity: isHovered ? 1 : 0,
-                                  transition: 'opacity 200ms',
+                                  transition: 'opacity 150ms',
                                   top: tooltipPosition.top,
                                   left: tooltipPosition.left,
                                 }}
-                                className="z-50 p-4 bg-white/95 dark:bg-gray-900/95 backdrop-blur-md text-gray-900 dark:text-gray-100 text-sm rounded-lg shadow-xl border border-gray-200/20 dark:border-gray-700/30"
+                                className="z-50 p-3 bg-popover border border-border text-foreground text-sm rounded-lg shadow-elevated"
                               >
-                                <div className="flex flex-wrap gap-2">
+                                <div className="flex flex-wrap gap-1.5">
                                   {players.map((p: Player) => (
                                     <span
                                       key={p.id}
-                                      className="bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 px-3 py-1 rounded-full border border-gray-200/50 dark:border-gray-700/50"
+                                      className="bg-muted text-muted-foreground px-2.5 py-0.5 rounded-md text-xs border border-border"
                                     >
                                       {p.playerName}
                                     </span>
@@ -426,22 +416,21 @@ export const LocationGroupHeader = ({
                             )}
                         </button>
                         <Copy
-                          className={`${ICON_SIZE.sm.class} ml-2 text-gray-800 dark:text-white group-hover/players:text-gray-200 transition-colors flex-shrink-0`}
+                          className={`${ICON_SIZE.sm.class} ml-2 text-muted-foreground group-hover/players:text-foreground transition-colors flex-shrink-0`}
                         />
                       </div>
                     );
                   }
                   return (
-                    // プレイヤーなし（取得済み、データなし = 0人）: 「プレイヤー情報なし」表示
-                    <div className="flex gap-2 items-center text-xs text-gray-800 dark:text-white backdrop-blur-sm bg-white/30 dark:bg-black/30 px-3 py-1 rounded-full border border-white/20 dark:border-gray-700/30 flex-1 min-w-0">
+                    <div className="flex gap-2 items-center text-xs text-foreground bg-muted/60 px-3 py-1 rounded-md border border-border flex-1 min-w-0">
                       <div className="flex items-center gap-1">
                         <Users
-                          className={`${ICON_SIZE.sm.class} text-primary-600 dark:text-primary-300 flex-shrink-0`}
+                          className={`${ICON_SIZE.sm.class} text-primary flex-shrink-0`}
                         />
                         <span>0</span>
                       </div>
-                      <div className="text-gray-500 dark:text-gray-400">|</div>
-                      <span className="text-gray-500 dark:text-gray-400">
+                      <div className="text-muted-foreground/40">|</div>
+                      <span className="text-muted-foreground">
                         {t('locationHeader.noPlayerInfo')}
                       </span>
                     </div>

--- a/src/v2/components/LocationGroupHeader/index.tsx
+++ b/src/v2/components/LocationGroupHeader/index.tsx
@@ -329,7 +329,7 @@ export const LocationGroupHeader = ({
                     onClick={openShareModal}
                     className="flex items-center text-sm font-medium text-foreground bg-muted hover:bg-muted/80 px-2.5 py-1 rounded-md transition-colors duration-150 border border-border"
                   >
-                    <Share2 className={`${ICON_SIZE.sm.class}`} />
+                    <Share2 className={ICON_SIZE.sm.class} />
                   </button>
                 </div>
               </div>

--- a/src/v2/components/LocationGroupHeader/index.tsx
+++ b/src/v2/components/LocationGroupHeader/index.tsx
@@ -236,7 +236,7 @@ export const LocationGroupHeader = ({
         )}
 
         <div className="relative flex items-center gap-4 w-full">
-          {/* 左側 - ワールド画像（ボーダーなし、丸く、影で浮遊感） */}
+          {/* ワールド画像 */}
           <div className="flex-shrink-0">
             {details?.thumbnailImageUrl ? (
               <div
@@ -256,7 +256,7 @@ export const LocationGroupHeader = ({
                 style={{ aspectRatio: '16/10' }}
               >
                 <ImageIcon
-                  className={`${ICON_SIZE.lg.class} text-muted-foreground/20`}
+                  className={`${ICON_SIZE.lg.class} text-muted-foreground/40`}
                 />
               </div>
             )}
@@ -308,14 +308,14 @@ export const LocationGroupHeader = ({
                 <button
                   type="button"
                   onClick={openShareModal}
-                  className="flex items-center text-sm text-muted-foreground/50 hover:text-foreground p-1.5 rounded-lg hover:bg-muted/40 transition-all duration-200 ease-spring"
+                  className="flex items-center text-sm text-muted-foreground hover:text-foreground p-1.5 rounded-lg hover:bg-muted/40 transition-all duration-200 ease-spring"
                 >
                   <Share2 className={ICON_SIZE.sm.class} />
                 </button>
               </div>
             </div>
 
-            {/* 2行目: 日付 + プレイヤー — ボーダーなし、テキストだけで情報を伝える */}
+            {/* 日付 + プレイヤー */}
             <div className="flex items-center gap-3 w-full text-xs text-muted-foreground">
               <span className="flex items-center gap-1 flex-shrink-0">
                 <Calendar className={ICON_SIZE.xs.class} />
@@ -395,7 +395,7 @@ export const LocationGroupHeader = ({
                           )}
                       </button>
                       <Copy
-                        className={`${ICON_SIZE.xs.class} ml-1 text-muted-foreground/30 group-hover/players:text-muted-foreground transition-colors duration-200 flex-shrink-0`}
+                        className={`${ICON_SIZE.xs.class} ml-1 text-muted-foreground/60 group-hover/players:text-muted-foreground transition-colors duration-200 flex-shrink-0`}
                       />
                     </div>
                   );

--- a/src/v2/components/LocationGroupHeader/index.tsx
+++ b/src/v2/components/LocationGroupHeader/index.tsx
@@ -11,10 +11,9 @@ import {
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
-import { Badge } from '@/components/ui/badge';
 import { trpcReact } from '@/trpc';
 
-import { ICON_SIZE, SPACING, TEXT_COLOR } from '../../constants/ui';
+import { ICON_SIZE, TEXT_COLOR } from '../../constants/ui';
 import { useI18n } from '../../i18n/store';
 import {
   getInstanceTypeColor,
@@ -202,19 +201,14 @@ export const LocationGroupHeader = ({
 
   if (worldId === null) {
     return (
-      <header
-        data-testid="location-group-header"
-        className={`w-full glass-panel rounded-t-xl ${SPACING.padding.section}`}
-      >
-        <div className={`flex items-center ${SPACING.inline.relaxed}`}>
-          <h2 className={`text-xl font-bold ${TEXT_COLOR.primary}`}>
-            {t('locationHeader.ungrouped')}
-          </h2>
-        </div>
+      <header data-testid="location-group-header" className="w-full px-5 py-4">
+        <h2 className={`text-lg font-semibold ${TEXT_COLOR.primary}`}>
+          {t('locationHeader.ungrouped')}
+        </h2>
         <div
-          className={`mt-2 text-sm ${TEXT_COLOR.secondary} flex items-center ${SPACING.inline.default}`}
+          className={`mt-1.5 text-xs ${TEXT_COLOR.secondary} flex items-center gap-1.5`}
         >
-          <Calendar className={ICON_SIZE.sm.class} />
+          <Calendar className={ICON_SIZE.xs.class} />
           <time dateTime={joinDateTime.toISOString()}>{formattedDate}</time>
         </div>
       </header>
@@ -225,218 +219,198 @@ export const LocationGroupHeader = ({
     <div
       ref={containerRef}
       data-testid="location-group-header"
-      className="w-full glass-panel rounded-t-lg overflow-hidden group/card"
+      className="w-full group/card rounded-xl overflow-hidden"
     >
-      <div className="relative h-24 overflow-hidden flex items-center justify-center">
-        <div className="absolute inset-0 bg-muted">
-          {details?.thumbnailImageUrl && isVisible && (
-            <>
-              <div
-                className="absolute inset-0 scale-105"
-                style={{
-                  backgroundImage: `url(${details.thumbnailImageUrl})`,
-                  backgroundSize: 'cover',
-                  backgroundPosition: 'center',
-                  filter: 'blur(24px) saturate(110%) brightness(0.95)',
-                }}
-              />
-              <div className="absolute inset-0 bg-background/80 dark:bg-background/60" />
-            </>
-          )}
-        </div>
+      <div className="relative overflow-hidden flex items-center px-6 py-5">
+        {/* 背景ブラー — ワールドの雰囲気を余韻として感じさせる */}
+        {details?.thumbnailImageUrl && isVisible && (
+          <div
+            className="absolute inset-0 scale-110 opacity-[0.06] dark:opacity-[0.1]"
+            style={{
+              backgroundImage: `url(${details.thumbnailImageUrl})`,
+              backgroundSize: 'cover',
+              backgroundPosition: 'center',
+              filter: 'blur(40px) saturate(150%)',
+            }}
+          />
+        )}
 
-        <div className="absolute inset-0 flex items-center justify-center p-2">
-          {/* 左側に画像、右側に情報 */}
-          <div className="flex items-center gap-4 w-full">
-            {/* 左側 - ワールド画像 */}
-            <div className="flex-shrink-0">
-              {details?.thumbnailImageUrl ? (
-                <div
-                  className="h-20 rounded-lg overflow-hidden border border-border/20 shadow-md"
-                  style={{ aspectRatio: '4/3' }}
+        <div className="relative flex items-center gap-4 w-full">
+          {/* 左側 - ワールド画像（ボーダーなし、丸く、影で浮遊感） */}
+          <div className="flex-shrink-0">
+            {details?.thumbnailImageUrl ? (
+              <div
+                className="h-14 rounded-lg overflow-hidden shadow-subtle transition-shadow duration-250 ease-spring group-hover/card:shadow-float"
+                style={{ aspectRatio: '16/10' }}
+              >
+                <img
+                  src={details.thumbnailImageUrl}
+                  alt={(details?.name || worldName) ?? 'World'}
+                  className="w-full h-full object-cover"
+                  loading="lazy"
+                />
+              </div>
+            ) : (
+              <div
+                className="h-14 rounded-lg bg-muted/40 flex items-center justify-center"
+                style={{ aspectRatio: '16/10' }}
+              >
+                <ImageIcon
+                  className={`${ICON_SIZE.lg.class} text-muted-foreground/20`}
+                />
+              </div>
+            )}
+          </div>
+
+          {/* 右側 - 情報 — 余白でグルーピング */}
+          <div className="flex-1 min-w-0 flex flex-col gap-2">
+            {/* 1行目: ワールド名とアクション */}
+            <div className="flex items-center justify-between">
+              <h3 className="text-base font-semibold flex items-center group/title text-foreground">
+                <button
+                  type="button"
+                  className="flex items-center transition-all duration-200 ease-spring hover:text-primary"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    openWorldLink(worldLink);
+                  }}
                 >
-                  <img
-                    src={details.thumbnailImageUrl}
-                    alt={(details?.name || worldName) ?? 'World'}
-                    className="w-full h-full object-cover"
-                    loading="lazy"
+                  <span className="line-clamp-1 text-start">
+                    {details?.name ?? worldName}
+                  </span>
+                  <ExternalLink
+                    className={`${ICON_SIZE.xs.class} ml-1.5 opacity-0 group-hover/title:opacity-60 transition-opacity duration-200 flex-shrink-0`}
                   />
-                </div>
-              ) : (
-                <div
-                  className="h-20 rounded-lg bg-muted flex items-center justify-center border border-border"
-                  style={{ aspectRatio: '4/3' }}
+                </button>
+              </h3>
+              <div className="flex items-center gap-1.5 flex-shrink-0">
+                {worldInstanceId &&
+                  shouldShowInstanceTypeBadge(worldInstanceId) && (
+                    <div
+                      className={`flex items-center text-[11px] font-medium px-2 py-0.5 rounded-lg transition-colors duration-200 ${getInstanceTypeColor(
+                        worldInstanceId,
+                      )}`}
+                    >
+                      {getInstanceTypeLabel(worldInstanceId)}
+                    </div>
+                  )}
+                {details?.unityPackages && details.unityPackages.length > 0 && (
+                  <div className="flex items-center gap-1">
+                    {[
+                      ...new Set(
+                        details.unityPackages.map((pkg) => pkg.platform),
+                      ),
+                    ].map((platform) => (
+                      <PlatformBadge key={platform} platform={platform} />
+                    ))}
+                  </div>
+                )}
+                <button
+                  type="button"
+                  onClick={openShareModal}
+                  className="flex items-center text-sm text-muted-foreground/50 hover:text-foreground p-1.5 rounded-lg hover:bg-muted/40 transition-all duration-200 ease-spring"
                 >
-                  <ImageIcon
-                    className={`${ICON_SIZE.lg.class} text-muted-foreground/30`}
-                  />
-                </div>
-              )}
+                  <Share2 className={ICON_SIZE.sm.class} />
+                </button>
+              </div>
             </div>
 
-            {/* 右側 - 情報 */}
-            <div className="flex-1 min-w-0 flex flex-col gap-2">
-              {/* 1行目: ワールド名とアクション */}
-              <div className="flex items-center justify-between">
-                <h3 className="text-lg font-semibold flex items-center group/title text-foreground">
-                  <button
-                    type="button"
-                    className="hover:underline flex items-center transition-colors duration-150 hover:text-primary"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      openWorldLink(worldLink);
-                    }}
-                  >
-                    <span className="line-clamp-1 text-start">
-                      {details?.name ?? worldName}
-                    </span>
-                    <ExternalLink
-                      className={`${ICON_SIZE.sm.class} ml-2 transition-opacity flex-shrink-0`}
-                    />
-                  </button>
-                </h3>
-                <div className="flex items-center gap-2 flex-shrink-0">
-                  {worldInstanceId &&
-                    shouldShowInstanceTypeBadge(worldInstanceId) && (
-                      <div
-                        className={`flex items-center text-xs font-medium px-2 py-0.5 rounded-md border transition-colors duration-150 ${getInstanceTypeColor(
-                          worldInstanceId,
-                        )}`}
-                      >
-                        {getInstanceTypeLabel(worldInstanceId)}
-                      </div>
-                    )}
-                  <Badge variant="glass" className="flex items-center text-sm">
-                    <Calendar
-                      className={`${ICON_SIZE.sm.class} mr-1.5 ${TEXT_COLOR.accent}`}
-                    />
-                    {formattedDate}
-                  </Badge>
-                  {details?.unityPackages &&
-                    details.unityPackages.length > 0 && (
-                      <div className="flex items-center gap-1.5">
-                        {[
-                          ...new Set(
-                            details.unityPackages.map((pkg) => pkg.platform),
-                          ),
-                        ].map((platform) => (
-                          <PlatformBadge key={platform} platform={platform} />
-                        ))}
-                      </div>
-                    )}
-                  <button
-                    type="button"
-                    onClick={openShareModal}
-                    className="flex items-center text-sm font-medium text-foreground bg-muted hover:bg-muted/80 px-2.5 py-1 rounded-md transition-colors duration-150 border border-border"
-                  >
-                    <Share2 className={ICON_SIZE.sm.class} />
-                  </button>
-                </div>
-              </div>
-
-              {/* 2行目: プレイヤーリスト */}
-              <div className="flex items-center gap-2 w-full">
-                {(() => {
-                  if (isPlayersLoading || players === null) {
-                    return (
-                      <div className="flex gap-2 items-center text-xs text-foreground bg-muted/60 px-3 py-1 rounded-md border border-border flex-1 min-w-0">
-                        <div className="flex items-center gap-1">
-                          <Users
-                            className={`${ICON_SIZE.sm.class} text-primary flex-shrink-0`}
-                          />
-                          <div className="h-4 w-6 bg-muted rounded animate-pulse" />
-                        </div>
-                        <div className="text-muted-foreground/40">|</div>
-                        <div className="flex-1 flex items-center gap-2">
-                          <div className="h-4 w-24 bg-muted rounded animate-pulse" />
-                          <div className="h-4 w-20 bg-muted rounded animate-pulse" />
-                          <div className="h-4 w-16 bg-muted rounded animate-pulse" />
-                        </div>
-                      </div>
-                    );
-                  }
-                  if (players.length > 0) {
-                    return (
-                      <div className="flex gap-2 items-center text-xs text-foreground bg-muted/60 hover:bg-muted/80 px-3 py-1 rounded-md transition-colors duration-150 border border-border group/players flex-1 min-w-0">
-                        <div className="flex items-center gap-1">
-                          <Users
-                            className={`${ICON_SIZE.sm.class} text-primary flex-shrink-0`}
-                          />
-                          <span>{players.length}</span>
-                        </div>
-                        <div className="text-muted-foreground/40">|</div>
-                        <button
-                          type="button"
-                          ref={playerListContainerRef}
-                          className="relative cursor-pointer flex-1 min-w-0 appearance-none border-none bg-transparent p-0 text-left"
-                          onMouseEnter={() => setIsHovered(true)}
-                          onMouseLeave={() => setIsHovered(false)}
-                          onMouseMove={handleMouseMove}
-                          onClick={() => void handleCopyPlayers()}
-                          title={t('locationHeader.clickToCopy')}
-                        >
-                          <div className="flex items-center gap-2 w-full">
-                            {isCopied ? (
-                              <span className="text-success flex items-center gap-2">
-                                <CheckIcon className={ICON_SIZE.sm.class} />
-                                {t('locationHeader.copied')}
-                              </span>
-                            ) : (
-                              <PlayerList
-                                players={players}
-                                maxVisiblePlayers={maxVisiblePlayers}
-                              />
-                            )}
-                          </div>
-                          {players &&
-                            createPortal(
-                              <div
-                                style={{
-                                  position: 'fixed',
-                                  visibility: isHovered ? 'visible' : 'hidden',
-                                  opacity: isHovered ? 1 : 0,
-                                  transition: 'opacity 150ms',
-                                  top: tooltipPosition.top,
-                                  left: tooltipPosition.left,
-                                }}
-                                className="z-50 p-3 bg-popover border border-border text-foreground text-sm rounded-lg shadow-elevated"
-                              >
-                                <div className="flex flex-wrap gap-1.5">
-                                  {players.map((p: Player) => (
-                                    <span
-                                      key={p.id}
-                                      className="bg-muted text-muted-foreground px-2.5 py-0.5 rounded-md text-xs border border-border"
-                                    >
-                                      {p.playerName}
-                                    </span>
-                                  ))}
-                                </div>
-                              </div>,
-                              document.body,
-                            )}
-                        </button>
-                        <Copy
-                          className={`${ICON_SIZE.sm.class} ml-2 text-muted-foreground group-hover/players:text-foreground transition-colors flex-shrink-0`}
-                        />
-                      </div>
-                    );
-                  }
+            {/* 2行目: 日付 + プレイヤー — ボーダーなし、テキストだけで情報を伝える */}
+            <div className="flex items-center gap-3 w-full text-xs text-muted-foreground">
+              <span className="flex items-center gap-1 flex-shrink-0">
+                <Calendar className={ICON_SIZE.xs.class} />
+                {formattedDate}
+              </span>
+              <span className="text-muted-foreground/20">·</span>
+              {(() => {
+                if (isPlayersLoading || players === null) {
                   return (
-                    <div className="flex gap-2 items-center text-xs text-foreground bg-muted/60 px-3 py-1 rounded-md border border-border flex-1 min-w-0">
-                      <div className="flex items-center gap-1">
-                        <Users
-                          className={`${ICON_SIZE.sm.class} text-primary flex-shrink-0`}
-                        />
-                        <span>0</span>
-                      </div>
-                      <div className="text-muted-foreground/40">|</div>
-                      <span className="text-muted-foreground">
-                        {t('locationHeader.noPlayerInfo')}
-                      </span>
+                    <div className="flex items-center gap-2 flex-1 min-w-0">
+                      <Users
+                        className={`${ICON_SIZE.xs.class} text-muted-foreground/40 flex-shrink-0`}
+                      />
+                      <div className="h-3 w-6 bg-muted/40 rounded-full animate-pulse" />
+                      <div className="h-3 w-20 bg-muted/40 rounded-full animate-pulse" />
                     </div>
                   );
-                })()}
-              </div>
+                }
+                if (players.length > 0) {
+                  return (
+                    <div className="flex items-center gap-1.5 group/players flex-1 min-w-0">
+                      <Users
+                        className={`${ICON_SIZE.xs.class} text-muted-foreground/40 flex-shrink-0`}
+                      />
+                      <span className="text-muted-foreground/60">
+                        {players.length}
+                      </span>
+                      <button
+                        type="button"
+                        ref={playerListContainerRef}
+                        className="relative cursor-pointer flex-1 min-w-0 appearance-none border-none bg-transparent p-0 text-left"
+                        onMouseEnter={() => setIsHovered(true)}
+                        onMouseLeave={() => setIsHovered(false)}
+                        onMouseMove={handleMouseMove}
+                        onClick={() => void handleCopyPlayers()}
+                        title={t('locationHeader.clickToCopy')}
+                      >
+                        <div className="flex items-center gap-1.5 w-full">
+                          {isCopied ? (
+                            <span className="text-success flex items-center gap-1">
+                              <CheckIcon className={ICON_SIZE.xs.class} />
+                              {t('locationHeader.copied')}
+                            </span>
+                          ) : (
+                            <PlayerList
+                              players={players}
+                              maxVisiblePlayers={maxVisiblePlayers}
+                            />
+                          )}
+                        </div>
+                        {players &&
+                          createPortal(
+                            <div
+                              style={{
+                                position: 'fixed',
+                                visibility: isHovered ? 'visible' : 'hidden',
+                                opacity: isHovered ? 1 : 0,
+                                transition:
+                                  'opacity 200ms cubic-bezier(0.22, 1, 0.36, 1)',
+                                top: tooltipPosition.top,
+                                left: tooltipPosition.left,
+                              }}
+                              className="z-50 p-3 bg-popover/95 backdrop-blur-xl text-foreground text-sm rounded-xl shadow-elevated"
+                            >
+                              <div className="flex flex-wrap gap-1.5">
+                                {players.map((p: Player) => (
+                                  <span
+                                    key={p.id}
+                                    className="bg-muted/60 text-muted-foreground px-2.5 py-0.5 rounded-lg text-xs"
+                                  >
+                                    {p.playerName}
+                                  </span>
+                                ))}
+                              </div>
+                            </div>,
+                            document.body,
+                          )}
+                      </button>
+                      <Copy
+                        className={`${ICON_SIZE.xs.class} ml-1 text-muted-foreground/30 group-hover/players:text-muted-foreground transition-colors duration-200 flex-shrink-0`}
+                      />
+                    </div>
+                  );
+                }
+                return (
+                  <div className="flex items-center gap-1.5 flex-1 min-w-0">
+                    <Users
+                      className={`${ICON_SIZE.xs.class} text-muted-foreground/40 flex-shrink-0`}
+                    />
+                    <span className="text-muted-foreground/40">
+                      {t('locationHeader.noPlayerInfo')}
+                    </span>
+                  </div>
+                );
+              })()}
             </div>
           </div>
         </div>

--- a/src/v2/components/PhotoCard.tsx
+++ b/src/v2/components/PhotoCard.tsx
@@ -269,9 +269,10 @@ const PhotoCard: React.FC<PhotoCardProps> = memo(
                   {selectionOrder}
                 </div>
               ) : (
+                // 写真上の選択アイコン — テーマに依存せず写真との固定コントラストが必要なため直接色指定
                 <Circle
                   size={ICON_SIZE.photo.pixels}
-                  className="text-white/80 bg-black/30 rounded-full hover:bg-black/40 transition-colors duration-150"
+                  className="text-primary-foreground/80 bg-foreground/30 rounded-full hover:bg-foreground/40 transition-colors duration-150"
                   strokeWidth={2}
                 />
               )}
@@ -311,15 +312,16 @@ const PhotoCard: React.FC<PhotoCardProps> = memo(
               </div>
             </div>
 
+            {/* ホバー時のファイル名オーバーレイ — 写真上で固定コントラストが必要なため直接色指定 */}
             {!isMultiSelectMode && photoLoaded && (
               <div
                 className={clsx(
-                  'absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent',
+                  'absolute inset-0 bg-gradient-to-t from-foreground/60 via-transparent to-transparent',
                   'opacity-0 group-hover:opacity-100 transition-opacity duration-150',
                 )}
               >
                 <div className="absolute bottom-0 left-0 right-0 p-3">
-                  <h3 className="text-white font-medium truncate text-xs drop-shadow-sm">
+                  <h3 className="text-primary-foreground font-medium truncate text-xs drop-shadow-sm">
                     {photo.fileNameWithExt.value}
                   </h3>
                 </div>

--- a/src/v2/components/PhotoCard.tsx
+++ b/src/v2/components/PhotoCard.tsx
@@ -227,11 +227,11 @@ const PhotoCard: React.FC<PhotoCardProps> = memo(
         type="button"
         ref={elementRef}
         className={clsx(
-          'photo-card group relative overflow-hidden transition-[opacity,padding] duration-150 ease-spring',
+          'photo-card group relative overflow-hidden rounded-lg transition-all duration-200 ease-spring',
           'cursor-pointer flex items-center justify-center',
           'appearance-none border-none p-0 text-left',
-          isSelected ? 'bg-muted' : 'bg-muted/60',
-          !isMultiSelectMode && 'hover:opacity-90',
+          isSelected ? 'bg-muted ring-2 ring-primary/30' : 'bg-muted/40',
+          !isMultiSelectMode && 'hover:shadow-float hover:scale-[1.008]',
         )}
         style={{
           height: displayHeight ? `${displayHeight}px` : undefined,
@@ -280,14 +280,14 @@ const PhotoCard: React.FC<PhotoCardProps> = memo(
 
             <div
               className={clsx(
-                'absolute inset-0 transition-all duration-150',
-                isSelected ? 'p-4' : 'p-0',
+                'absolute inset-0 transition-all duration-250 ease-spring',
+                isSelected ? 'p-3' : 'p-0',
               )}
             >
               <div
                 className={clsx(
                   'relative w-full h-full overflow-hidden',
-                  isSelected ? 'rounded-sm' : '',
+                  isSelected ? 'rounded-md' : '',
                 )}
               >
                 {shouldLoad ? (
@@ -316,8 +316,8 @@ const PhotoCard: React.FC<PhotoCardProps> = memo(
             {!isMultiSelectMode && photoLoaded && (
               <div
                 className={clsx(
-                  'absolute inset-0 bg-gradient-to-t from-foreground/60 via-transparent to-transparent',
-                  'opacity-0 group-hover:opacity-100 transition-opacity duration-150',
+                  'absolute inset-0 bg-gradient-to-t from-foreground/50 via-transparent to-transparent',
+                  'opacity-0 group-hover:opacity-100 transition-opacity duration-250 ease-spring',
                 )}
               >
                 <div className="absolute bottom-0 left-0 right-0 p-3">

--- a/src/v2/components/PhotoCard.tsx
+++ b/src/v2/components/PhotoCard.tsx
@@ -227,11 +227,11 @@ const PhotoCard: React.FC<PhotoCardProps> = memo(
         type="button"
         ref={elementRef}
         className={clsx(
-          'photo-card group relative overflow-hidden transition-all duration-150',
+          'photo-card group relative overflow-hidden transition-[opacity,padding] duration-150 ease-spring',
           'cursor-pointer flex items-center justify-center',
           'appearance-none border-none p-0 text-left',
           isSelected ? 'bg-muted' : 'bg-muted/60',
-          !isMultiSelectMode && 'hover:brightness-105 hover:shadow-sm',
+          !isMultiSelectMode && 'hover:opacity-90',
         )}
         style={{
           height: displayHeight ? `${displayHeight}px` : undefined,
@@ -271,7 +271,7 @@ const PhotoCard: React.FC<PhotoCardProps> = memo(
               ) : (
                 <Circle
                   size={ICON_SIZE.photo.pixels}
-                  className="text-white/90 bg-gray-900/40 backdrop-blur-sm rounded-full hover:bg-gray-900/60 transition-colors duration-150"
+                  className="text-white/80 bg-black/30 rounded-full hover:bg-black/40 transition-colors duration-150"
                   strokeWidth={2}
                 />
               )}

--- a/src/v2/components/PhotoGallery/GalleryContent.tsx
+++ b/src/v2/components/PhotoGallery/GalleryContent.tsx
@@ -306,7 +306,7 @@ const VirtualizedGallery = memo(
                   }}
                 >
                   {isGroupFullyLoaded ? (
-                    <div className="w-full space-y-0">
+                    <div className="w-full">
                       <LocationGroupHeader
                         worldId={group.worldInfo?.worldId ?? null}
                         worldName={group.worldInfo?.worldName ?? null}
@@ -316,7 +316,7 @@ const VirtualizedGallery = memo(
                         photoCount={group.photos.length}
                         joinDateTime={group.joinDateTime}
                       />
-                      <div className="w-full rounded-b-lg overflow-hidden">
+                      <div className="w-full overflow-hidden">
                         <PhotoGrid
                           photos={group.photos}
                           effectiveWidth={widthValue}
@@ -344,7 +344,7 @@ const VirtualizedGallery = memo(
             })}
           </div>
           {isLoading && (
-            <div className="fixed bottom-4 right-6 flex items-center space-x-2 bg-background/80 backdrop-blur-sm rounded-lg px-4 py-2 shadow-lg">
+            <div className="fixed bottom-4 right-6 flex items-center space-x-2 bg-popover/90 backdrop-blur-xl rounded-xl px-4 py-2.5 shadow-elevated">
               <LoaderCircle className="w-4 h-4 animate-spin text-muted-foreground" />
               <div className="text-sm text-muted-foreground">読み込み中...</div>
             </div>

--- a/src/v2/components/PhotoGallery/GalleryErrorBoundary.tsx
+++ b/src/v2/components/PhotoGallery/GalleryErrorBoundary.tsx
@@ -46,8 +46,8 @@ export class GalleryErrorBoundary extends React.Component<Props, State> {
               </h2>
             </div>
 
-            <div className="mb-8 rounded-md bg-white p-4">
-              <p className="font-mono text-sm text-red-500">
+            <div className="mb-8 rounded-md bg-card p-4 border border-border">
+              <p className="font-mono text-sm text-destructive">
                 {this.state.errorMessage}
               </p>
             </div>

--- a/src/v2/components/PhotoGrid.tsx
+++ b/src/v2/components/PhotoGrid.tsx
@@ -80,13 +80,13 @@ export default function PhotoGrid({
 
   return (
     <div className="w-full">
-      <div className="space-y-1">
+      <div className="space-y-1.5">
         {layout.map((row, rowIndex) => {
           const rowKey = `row-${rowIndex}-${row[0]?.id}`;
           return (
             <div
               key={rowKey}
-              className="flex gap-1"
+              className="flex gap-1.5"
               style={{
                 height: row[0]?.displayHeight ?? 200,
               }}

--- a/src/v2/components/SearchCombobox.tsx
+++ b/src/v2/components/SearchCombobox.tsx
@@ -38,7 +38,7 @@ const SearchCombobox = memo(
         <button
           type="button"
           onClick={handleOpenOverlay}
-          className={`relative flex items-center w-full h-7 bg-popover/60 backdrop-blur-xl rounded-2xl border-0 px-4 py-2 text-sm font-medium transition-all duration-300 hover:bg-popover/70 hover:shadow-md hover:shadow-black/5 dark:hover:shadow-white/5 ${
+          className={`relative flex items-center w-full h-7 bg-muted rounded-lg px-3 py-2 text-sm font-medium transition-colors duration-150 hover:bg-muted/80 ${
             className ?? ''
           }`}
           aria-label="検索を開く"

--- a/src/v2/components/SearchCombobox.tsx
+++ b/src/v2/components/SearchCombobox.tsx
@@ -1,5 +1,6 @@
 import { Search } from 'lucide-react';
 import { memo, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 import { useI18n } from '../i18n/store';
 import SearchOverlay from './SearchOverlay';
@@ -38,29 +39,32 @@ const SearchCombobox = memo(
         <button
           type="button"
           onClick={handleOpenOverlay}
-          className={`relative flex items-center w-full h-7 bg-muted rounded-lg px-3 py-2 text-sm font-medium transition-colors duration-150 hover:bg-muted/80 ${
+          className={`relative flex items-center w-full h-8 bg-muted/50 rounded-xl px-3.5 text-sm font-medium transition-all duration-200 ease-spring hover:bg-muted/70 hover:shadow-subtle hover:scale-[1.01] active:scale-[0.99] ${
             className ?? ''
           }`}
           aria-label="検索を開く"
         >
-          <Search className="h-4 w-4 text-muted-foreground/30 mr-3 flex-shrink-0" />
-          <span className="flex-1 text-left text-muted-foreground/50 truncate">
+          <Search className="h-3.5 w-3.5 text-muted-foreground/30 mr-3 flex-shrink-0" />
+          <span className="flex-1 text-left text-muted-foreground/40 truncate">
             {searchQuery || t('common.search.placeholder')}
           </span>
           {searchQuery && (
-            <div className="ml-2 text-xs text-muted-foreground/60 bg-muted/50 px-2 py-0.5 rounded-md">
+            <div className="ml-2 text-xs text-muted-foreground/60 bg-muted/40 px-2 py-0.5 rounded-lg">
               検索中
             </div>
           )}
         </button>
 
-        {/* 検索オーバーレイ */}
-        <SearchOverlay
-          isOpen={isOverlayOpen}
-          onClose={handleCloseOverlay}
-          onSearch={handleSearch}
-          initialQuery={searchQuery}
-        />
+        {/* 検索オーバーレイ — ヘッダーの backdrop-filter スタッキングコンテキストを超えるため Portal 経由 */}
+        {createPortal(
+          <SearchOverlay
+            isOpen={isOverlayOpen}
+            onClose={handleCloseOverlay}
+            onSearch={handleSearch}
+            initialQuery={searchQuery}
+          />,
+          document.body,
+        )}
       </>
     );
   },

--- a/src/v2/components/SearchCombobox.tsx
+++ b/src/v2/components/SearchCombobox.tsx
@@ -55,16 +55,16 @@ const SearchCombobox = memo(
           )}
         </button>
 
-        {/* 検索オーバーレイ — ヘッダーの backdrop-filter スタッキングコンテキストを超えるため Portal 経由 */}
-        {createPortal(
-          <SearchOverlay
-            isOpen={isOverlayOpen}
-            onClose={handleCloseOverlay}
-            onSearch={handleSearch}
-            initialQuery={searchQuery}
-          />,
-          document.body,
-        )}
+        {isOverlayOpen &&
+          createPortal(
+            <SearchOverlay
+              isOpen={isOverlayOpen}
+              onClose={handleCloseOverlay}
+              onSearch={handleSearch}
+              initialQuery={searchQuery}
+            />,
+            document.body,
+          )}
       </>
     );
   },

--- a/src/v2/components/SearchOverlay.tsx
+++ b/src/v2/components/SearchOverlay.tsx
@@ -239,22 +239,22 @@ const SearchOverlay = memo(
         aria-modal="true"
         tabIndex={-1}
       >
-        <div className="absolute top-0 left-0 right-0 p-4 pointer-events-none">
+        <div className="absolute top-0 left-0 right-0 pt-16 px-4 pointer-events-none">
           <div
-            className="max-w-2xl mx-auto bg-popover rounded-lg border border-border shadow-elevated pointer-events-auto"
+            className="max-w-xl mx-auto bg-popover/95 backdrop-blur-xl rounded-2xl shadow-elevated pointer-events-auto overflow-hidden"
             role="search"
             onClick={(e) => e.stopPropagation()}
             onKeyDown={(e) => e.stopPropagation()}
           >
-            {/* 検索入力部分 */}
-            <div className="flex items-center p-4 border-b border-border/30">
+            {/* 検索入力部分 — 大きくてスペーシー */}
+            <div className="flex items-center px-5 py-4">
               <Search
-                className={`${ICON_SIZE.md.class} text-muted-foreground/40 mr-3 flex-shrink-0`}
+                className={`${ICON_SIZE.md.class} text-muted-foreground/30 mr-4 flex-shrink-0`}
               />
               <input
                 ref={inputRef}
                 type="text"
-                className="flex-1 bg-transparent text-lg font-medium placeholder:text-muted-foreground/50 focus:outline-none"
+                className="flex-1 bg-transparent text-lg font-medium placeholder:text-muted-foreground/40 focus:outline-none"
                 placeholder={t('common.search.placeholder')}
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
@@ -268,29 +268,29 @@ const SearchOverlay = memo(
                     setQuery('');
                     onSearch('');
                   }}
-                  className="ml-3 p-1.5 hover:bg-muted/50 rounded-lg transition-colors duration-150"
+                  className="ml-3 p-1.5 hover:bg-muted/40 rounded-full transition-all duration-200 ease-spring"
                   aria-label="検索をクリア"
                 >
                   <X
-                    className={`${ICON_SIZE.sm.class} text-muted-foreground/60`}
+                    className={`${ICON_SIZE.sm.class} text-muted-foreground/50`}
                   />
                 </button>
               )}
             </div>
 
-            {/* 検索候補部分 */}
+            {/* 検索候補部分 — ボーダーなし、余白で区切る */}
             <div className="max-h-80 overflow-y-auto scrollbar-hide">
               {(() => {
                 if (isLoading && debouncedQuery.length > 0) {
                   return (
-                    <div className="p-6 text-center text-muted-foreground/80">
+                    <div className="px-5 py-6 text-center text-muted-foreground/60 text-sm">
                       検索中...
                     </div>
                   );
                 }
                 if (suggestions.length === 0) {
                   return (
-                    <div className="p-6 text-center text-muted-foreground/80">
+                    <div className="px-5 py-6 text-center text-muted-foreground/60 text-sm">
                       {debouncedQuery.length > 0
                         ? '候補が見つかりません'
                         : 'よく利用する項目を読み込み中...'}
@@ -298,19 +298,19 @@ const SearchOverlay = memo(
                   );
                 }
                 return (
-                  <div className="p-2">
+                  <div className="px-2 pb-2">
                     {debouncedQuery.length === 0 && (
-                      <div className="px-3 py-2 text-xs font-medium text-muted-foreground/60 uppercase tracking-wide">
+                      <div className="px-3 pt-1 pb-2 text-[11px] font-medium text-muted-foreground/40 uppercase tracking-wider">
                         よく利用する項目
                       </div>
                     )}
                     {suggestions.map((suggestion, index) => (
                       <div
                         key={suggestion.id}
-                        className={`flex items-center px-3 py-2.5 rounded-md cursor-pointer transition-colors duration-150 ${
+                        className={`flex items-center px-3 py-2.5 rounded-xl cursor-pointer transition-all duration-200 ease-spring ${
                           index === highlightedIndex
-                            ? 'bg-accent'
-                            : 'hover:bg-muted'
+                            ? 'bg-muted/60'
+                            : 'hover:bg-muted/40'
                         }`}
                         onClick={() => handleSelect(suggestion)}
                         onKeyDown={(e) => {
@@ -326,23 +326,23 @@ const SearchOverlay = memo(
                       >
                         {suggestion.type === 'world' ? (
                           <Globe
-                            className={`${ICON_SIZE.sm.class} mr-3 text-muted-foreground`}
+                            className={`${ICON_SIZE.sm.class} mr-3 text-muted-foreground/50`}
                           />
                         ) : (
                           <User
-                            className={`${ICON_SIZE.sm.class} mr-3 text-muted-foreground`}
+                            className={`${ICON_SIZE.sm.class} mr-3 text-muted-foreground/50`}
                           />
                         )}
                         <span className="flex-1 font-medium text-foreground">
                           {suggestion.label}
                         </span>
                         {suggestion.type === 'world' && (
-                          <span className="text-xs text-muted-foreground/60 bg-muted/50 px-2 py-1 rounded-md">
+                          <span className="text-[11px] text-muted-foreground/40 px-2 py-0.5 rounded-lg">
                             ワールド
                           </span>
                         )}
                         {suggestion.type === 'player' && (
-                          <span className="text-xs text-muted-foreground/60 bg-muted/50 px-2 py-1 rounded-md">
+                          <span className="text-[11px] text-muted-foreground/40 px-2 py-0.5 rounded-lg">
                             プレイヤー
                           </span>
                         )}
@@ -353,13 +353,13 @@ const SearchOverlay = memo(
               })()}
             </div>
 
-            {/* フッター（オプション） */}
+            {/* フッター — ボーダーなし、余白で分離 */}
             {query.trim() && (
-              <div className="border-t border-border/30 p-3">
+              <div className="px-3 pb-3">
                 <button
                   type="button"
                   onClick={handleSearch}
-                  className="w-full flex items-center justify-center px-4 py-2 bg-primary/10 hover:bg-primary/15 text-primary font-medium rounded-md transition-colors duration-150"
+                  className="w-full flex items-center justify-center px-4 py-2.5 bg-primary/8 hover:bg-primary/12 text-primary font-medium rounded-xl transition-all duration-200 ease-spring hover:scale-[1.01] active:scale-[0.99]"
                 >
                   <Search className={`${ICON_SIZE.sm.class} mr-2`} />「{query}
                   」で検索

--- a/src/v2/components/SearchOverlay.tsx
+++ b/src/v2/components/SearchOverlay.tsx
@@ -278,7 +278,7 @@ const SearchOverlay = memo(
               )}
             </div>
 
-            {/* 検索候補部分 — ボーダーなし、余白で区切る */}
+            {/* 検索候補 */}
             <div className="max-h-80 overflow-y-auto scrollbar-hide">
               {(() => {
                 if (isLoading && debouncedQuery.length > 0) {
@@ -353,7 +353,7 @@ const SearchOverlay = memo(
               })()}
             </div>
 
-            {/* フッター — ボーダーなし、余白で分離 */}
+            {/* フッター */}
             {query.trim() && (
               <div className="px-3 pb-3">
                 <button

--- a/src/v2/components/SearchOverlay.tsx
+++ b/src/v2/components/SearchOverlay.tsx
@@ -228,7 +228,7 @@ const SearchOverlay = memo(
 
     return (
       <div
-        className="fixed inset-0 z-50 bg-black/20 dark:bg-black/40 backdrop-blur-sm"
+        className="fixed inset-0 z-50 bg-black/20 backdrop-blur-sm"
         onClick={handleBackdropClick}
         onKeyDown={(e) => {
           if (e.key === 'Escape') {
@@ -241,7 +241,7 @@ const SearchOverlay = memo(
       >
         <div className="absolute top-0 left-0 right-0 p-4 pointer-events-none">
           <div
-            className="max-w-2xl mx-auto bg-popover/95 backdrop-blur-2xl rounded-2xl border border-border/20 shadow-2xl pointer-events-auto"
+            className="max-w-2xl mx-auto bg-popover rounded-lg border border-border shadow-elevated pointer-events-auto"
             role="search"
             onClick={(e) => e.stopPropagation()}
             onKeyDown={(e) => e.stopPropagation()}
@@ -307,10 +307,10 @@ const SearchOverlay = memo(
                     {suggestions.map((suggestion, index) => (
                       <div
                         key={suggestion.id}
-                        className={`flex items-center px-3 py-2.5 rounded-xl cursor-pointer transition-colors duration-150 ${
+                        className={`flex items-center px-3 py-2.5 rounded-md cursor-pointer transition-colors duration-150 ${
                           index === highlightedIndex
-                            ? 'bg-primary/10 dark:bg-primary/20'
-                            : 'hover:bg-muted/50'
+                            ? 'bg-accent'
+                            : 'hover:bg-muted'
                         }`}
                         onClick={() => handleSelect(suggestion)}
                         onKeyDown={(e) => {
@@ -359,7 +359,7 @@ const SearchOverlay = memo(
                 <button
                   type="button"
                   onClick={handleSearch}
-                  className="w-full flex items-center justify-center px-4 py-2 bg-primary/10 hover:bg-primary/20 dark:bg-primary/20 dark:hover:bg-primary/30 text-primary font-medium rounded-xl transition-colors duration-150"
+                  className="w-full flex items-center justify-center px-4 py-2 bg-primary/10 hover:bg-primary/15 text-primary font-medium rounded-md transition-colors duration-150"
                 >
                   <Search className={`${ICON_SIZE.sm.class} mr-2`} />「{query}
                   」で検索

--- a/src/v2/components/settings/AppInfo.tsx
+++ b/src/v2/components/settings/AppInfo.tsx
@@ -14,14 +14,7 @@ import { trpcClient, trpcReact } from '@/trpc';
 
 import packageJson from '../../../../package.json';
 import { Button } from '../../../components/ui/button';
-import {
-  ICON_SIZE,
-  SPACING,
-  STATUS_COLOR,
-  SURFACE_COLOR,
-  TEXT_COLOR,
-  TYPOGRAPHY,
-} from '../../constants/ui';
+import { ICON_SIZE, STATUS_COLOR, TYPOGRAPHY } from '../../constants/ui';
 import { useI18n } from '../../i18n/store';
 import { SettingsSection } from './common';
 import SqliteConsole from './SqliteConsole';
@@ -140,35 +133,33 @@ const AppInfo = memo(() => {
 
   return (
     <SettingsSection icon={Info} title={t('settings.info.title')}>
-      <div
-        className={`${SURFACE_COLOR.muted} rounded-lg ${SPACING.padding.card} ${SPACING.stack.tight}`}
-      >
-        <div className="flex justify-between">
-          <span className={TEXT_COLOR.secondary}>
+      <div className="space-y-5">
+        <div className="flex justify-between items-center">
+          <span className="text-sm text-muted-foreground">
             {t('settings.info.version')}
           </span>
           <button
             type="button"
-            className={`font-mono ${TEXT_COLOR.primary} cursor-pointer appearance-none border-none bg-transparent p-0`}
+            className="font-mono text-sm text-foreground cursor-pointer appearance-none border-none bg-transparent p-0"
             onClick={handleVersionClick}
             onKeyDown={handleKeyDown}
           >
             {appVersion}
           </button>
         </div>
-        <div className="flex justify-between">
-          <span className={TEXT_COLOR.secondary}>
+        <div className="flex justify-between items-center">
+          <span className="text-sm text-muted-foreground">
             {t('settings.info.name')}
           </span>
-          <span className={`font-mono ${TEXT_COLOR.primary}`}>
+          <span className="font-mono text-sm text-foreground">
             {packageJson.name}
           </span>
         </div>
 
         {/* アップデートセクション */}
-        <div className="flex flex-col gap-2 mt-4">
+        <div className="flex flex-col gap-3">
           <div className="flex items-center justify-between">
-            <span className={TEXT_COLOR.secondary}>
+            <span className="text-sm text-muted-foreground">
               {t('settings.info.update.checkForUpdates')}
             </span>
             <Button
@@ -256,8 +247,8 @@ const AppInfo = memo(() => {
           )}
         </div>
 
-        <div className="flex justify-between mt-4">
-          <span className={TEXT_COLOR.secondary}>
+        <div className="flex justify-between items-center">
+          <span className="text-sm text-muted-foreground">
             {t('settings.info.openLog')}
           </span>
           <Button variant="outline" size="sm" onClick={handleOpenLog}>

--- a/src/v2/components/settings/DataExport.tsx
+++ b/src/v2/components/settings/DataExport.tsx
@@ -159,28 +159,26 @@ const DataExport = memo(() => {
           </Label>
 
           {/* プリセット選択 - ThemeSelectorパターン */}
-          <div className="grid grid-cols-3 gap-2">
+          <div className="grid grid-cols-3 gap-3">
             {periodPresets.map(({ value, label, icon: Icon }) => (
               <button
                 type="button"
                 key={value}
                 onClick={() => handlePresetSelect(value)}
                 className={cn(
-                  'flex items-center justify-center gap-2 p-3 rounded-xl transition-all duration-200 ease-spring',
+                  'flex flex-col items-center justify-center gap-2.5 py-5 px-4 rounded-xl transition-all duration-200 ease-spring',
                   selectedPreset === value
-                    ? 'bg-muted/70 shadow-subtle text-foreground'
-                    : 'text-muted-foreground hover:bg-muted/40 hover:text-foreground',
+                    ? 'bg-muted/50 text-foreground'
+                    : 'text-muted-foreground/50 hover:bg-muted/25 hover:text-foreground',
                 )}
               >
                 <Icon
                   className={cn(
-                    'h-4 w-4',
-                    selectedPreset === value
-                      ? 'text-primary'
-                      : 'text-muted-foreground/50',
+                    'h-5 w-5',
+                    selectedPreset === value ? 'text-primary' : 'opacity-40',
                   )}
                 />
-                <span className={cn(TYPOGRAPHY.body.emphasis)}>{label}</span>
+                <span className="text-[13px] font-medium">{label}</span>
               </button>
             ))}
           </div>

--- a/src/v2/components/settings/DataExport.tsx
+++ b/src/v2/components/settings/DataExport.tsx
@@ -178,7 +178,7 @@ const DataExport = memo(() => {
                     selectedPreset === value ? 'text-primary' : 'opacity-40',
                   )}
                 />
-                <span className="text-[13px] font-medium">{label}</span>
+                <span className="text-sm font-medium">{label}</span>
               </button>
             ))}
           </div>

--- a/src/v2/components/settings/DataExport.tsx
+++ b/src/v2/components/settings/DataExport.tsx
@@ -168,7 +168,7 @@ const DataExport = memo(() => {
                 className={cn(
                   'flex items-center justify-center gap-2 p-3 rounded-lg border-2 transition-colors',
                   selectedPreset === value
-                    ? 'border-primary bg-primary/10 dark:bg-primary/20'
+                    ? 'border-primary bg-primary/10'
                     : 'border-border hover:border-primary/50',
                 )}
               >

--- a/src/v2/components/settings/DataExport.tsx
+++ b/src/v2/components/settings/DataExport.tsx
@@ -151,10 +151,8 @@ const DataExport = memo(() => {
     >
       <div className={SPACING.stack.relaxed}>
         {/* 期間設定 */}
-        <div className={SPACING.stack.default}>
-          <Label
-            className={`${TYPOGRAPHY.body.emphasis} ${TEXT_COLOR.secondary}`}
-          >
+        <div className="space-y-6">
+          <Label className="text-sm text-muted-foreground">
             エクスポート期間
           </Label>
 
@@ -231,11 +229,8 @@ const DataExport = memo(() => {
         </div>
 
         {/* 出力パス設定 */}
-        <div className={SPACING.stack.tight}>
-          <Label
-            htmlFor="outputPath"
-            className={`${TYPOGRAPHY.body.emphasis} ${TEXT_COLOR.secondary}`}
-          >
+        <div className="space-y-6">
+          <Label htmlFor="outputPath" className="text-sm text-muted-foreground">
             出力先ディレクトリ（オプション）
           </Label>
           <div className="flex gap-2">

--- a/src/v2/components/settings/DataExport.tsx
+++ b/src/v2/components/settings/DataExport.tsx
@@ -15,7 +15,7 @@ import { Input } from '../../../components/ui/input';
 import { Label } from '../../../components/ui/label';
 import { SPACING, TEXT_COLOR, TYPOGRAPHY } from '../../constants/ui';
 import { useToast } from '../../hooks/use-toast';
-import { SettingsInfoBox, SettingsSection } from './common';
+import { SettingsField, SettingsInfoBox, SettingsSection } from './common';
 
 type PeriodPreset = 'all' | 'recent3months' | 'custom';
 
@@ -151,11 +151,7 @@ const DataExport = memo(() => {
     >
       <div className={SPACING.stack.relaxed}>
         {/* 期間設定 */}
-        <div className="space-y-6">
-          <Label className="text-sm text-muted-foreground">
-            エクスポート期間
-          </Label>
-
+        <SettingsField label="エクスポート期間">
           {/* プリセット選択 - ThemeSelectorパターン */}
           <div className="grid grid-cols-3 gap-3">
             {periodPresets.map(({ value, label, icon: Icon }) => (
@@ -226,13 +222,13 @@ const DataExport = memo(() => {
               </div>
             </div>
           )}
-        </div>
+        </SettingsField>
 
         {/* 出力パス設定 */}
-        <div className="space-y-6">
-          <Label htmlFor="outputPath" className="text-sm text-muted-foreground">
-            出力先ディレクトリ（オプション）
-          </Label>
+        <SettingsField
+          label="出力先ディレクトリ（オプション）"
+          htmlFor="outputPath"
+        >
           <div className="flex gap-2">
             <div className="relative flex-1">
               <FolderOpen
@@ -259,7 +255,7 @@ const DataExport = memo(() => {
           <p className={`${TYPOGRAPHY.body.small} ${TEXT_COLOR.muted}`}>
             出力先を変更しない場合、ダウンロードフォルダ内のlogStoreディレクトリに出力されます
           </p>
-        </div>
+        </SettingsField>
 
         {/* エクスポートボタン */}
         <div className="pt-4">

--- a/src/v2/components/settings/DataExport.tsx
+++ b/src/v2/components/settings/DataExport.tsx
@@ -159,37 +159,28 @@ const DataExport = memo(() => {
           </Label>
 
           {/* プリセット選択 - ThemeSelectorパターン */}
-          <div className="grid grid-cols-3 gap-3">
+          <div className="grid grid-cols-3 gap-2">
             {periodPresets.map(({ value, label, icon: Icon }) => (
               <button
                 type="button"
                 key={value}
                 onClick={() => handlePresetSelect(value)}
                 className={cn(
-                  'flex items-center justify-center gap-2 p-3 rounded-lg border-2 transition-colors',
+                  'flex items-center justify-center gap-2 p-3 rounded-xl transition-all duration-200 ease-spring',
                   selectedPreset === value
-                    ? 'border-primary bg-primary/10'
-                    : 'border-border hover:border-primary/50',
+                    ? 'bg-muted/70 shadow-subtle text-foreground'
+                    : 'text-muted-foreground hover:bg-muted/40 hover:text-foreground',
                 )}
               >
                 <Icon
                   className={cn(
-                    'h-5 w-5',
+                    'h-4 w-4',
                     selectedPreset === value
                       ? 'text-primary'
-                      : TEXT_COLOR.muted,
+                      : 'text-muted-foreground/50',
                   )}
                 />
-                <span
-                  className={cn(
-                    TYPOGRAPHY.body.emphasis,
-                    selectedPreset === value
-                      ? 'text-primary'
-                      : TEXT_COLOR.secondary,
-                  )}
-                >
-                  {label}
-                </span>
+                <span className={cn(TYPOGRAPHY.body.emphasis)}>{label}</span>
               </button>
             ))}
           </div>

--- a/src/v2/components/settings/DataImport.tsx
+++ b/src/v2/components/settings/DataImport.tsx
@@ -219,7 +219,7 @@ const DataImport = memo(() => {
     >
       <div className="space-y-10">
         {/* ファイル選択・ドロップエリア */}
-        <div className="space-y-5">
+        <div className="space-y-6">
           <Label className="text-sm text-muted-foreground">
             インポートファイル
           </Label>

--- a/src/v2/components/settings/DataImport.tsx
+++ b/src/v2/components/settings/DataImport.tsx
@@ -220,7 +220,7 @@ const DataImport = memo(() => {
       <div className="space-y-10">
         {/* ファイル選択・ドロップエリア */}
         <SettingsField label="インポートファイル">
-          {/* ドロップエリア — ボーダーなし、背景だけ */}
+          {/* ドロップエリア */}
           <div
             className={`rounded-2xl py-12 px-8 text-center transition-all duration-200 ease-spring ${
               isDragOver ? 'bg-primary/[0.06] scale-[1.01]' : 'bg-muted/20'

--- a/src/v2/components/settings/DataImport.tsx
+++ b/src/v2/components/settings/DataImport.tsx
@@ -217,45 +217,43 @@ const DataImport = memo(() => {
       title="ログデータインポート"
       description="エクスポートされたlogStoreファイルを既存のデータに統合します"
     >
-      <div className={SPACING.stack.relaxed}>
+      <div className="space-y-10">
         {/* ファイル選択・ドロップエリア */}
-        <div className={SPACING.stack.default}>
-          <Label
-            className={`${TYPOGRAPHY.body.emphasis} ${TEXT_COLOR.secondary}`}
-          >
+        <div className="space-y-5">
+          <Label className="text-[12px] text-muted-foreground/45">
             インポートファイル
           </Label>
 
-          {/* ドロップエリア */}
+          {/* ドロップエリア — ボーダーなし、背景だけ */}
           <div
-            className={`rounded-2xl p-8 text-center transition-all duration-200 ease-spring ${
-              isDragOver ? 'bg-primary/8 scale-[1.01]' : 'bg-muted/30'
+            className={`rounded-2xl py-12 px-8 text-center transition-all duration-200 ease-spring ${
+              isDragOver ? 'bg-primary/[0.06] scale-[1.01]' : 'bg-muted/20'
             }`}
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
             onDrop={handleDrop}
           >
-            <Upload className={`h-8 w-8 mx-auto mb-2 ${TEXT_COLOR.muted}`} />
-            <p
-              className={`${TYPOGRAPHY.body.small} ${TEXT_COLOR.secondary} mb-3`}
-            >
+            <Upload className="h-6 w-6 mx-auto mb-4 text-muted-foreground/25" />
+            <p className="text-[12px] text-muted-foreground/40 mb-5 leading-relaxed">
               logStoreファイルやディレクトリをドラッグ&amp;ドロップするか、下のボタンで選択してください
             </p>
-            <div className="flex gap-2 justify-center">
+            <div className="flex gap-3 justify-center">
               <Button
                 type="button"
-                variant="outline"
+                variant="ghost"
                 onClick={() => void selectFiles()}
                 size="sm"
+                className="text-muted-foreground/50 hover:text-foreground"
               >
                 <FileText className="h-4 w-4 mr-2" />
                 ファイル選択
               </Button>
               <Button
                 type="button"
-                variant="outline"
+                variant="ghost"
                 onClick={() => void selectDirectory()}
                 size="sm"
+                className="text-muted-foreground/50 hover:text-foreground"
               >
                 <FolderOpen className="h-4 w-4 mr-2" />
                 ディレクトリ選択
@@ -265,20 +263,18 @@ const DataImport = memo(() => {
 
           {/* 選択されたパス一覧 */}
           {selectedPaths.length > 0 && (
-            <div className={SPACING.stack.tight}>
-              <Label
-                className={`${TYPOGRAPHY.body.small} ${TEXT_COLOR.secondary}`}
-              >
+            <div className="space-y-4">
+              <Label className="text-[12px] text-muted-foreground/45">
                 選択されたアイテム ({selectedPaths.length}個)
               </Label>
-              <div className="max-h-32 overflow-y-auto space-y-1">
+              <div className="max-h-32 overflow-y-auto space-y-2">
                 {selectedPaths.map((pathItem) => (
                   <div
                     key={pathItem}
-                    className={`${TYPOGRAPHY.body.small} ${STATUS_BADGE.primary} p-2 rounded`}
+                    className="text-[12px] text-foreground/70 bg-muted/20 px-4 py-3 rounded-xl"
                   >
                     {getFilenameFromPath(pathItem)}
-                    <div className={`${TEXT_COLOR.muted} truncate`}>
+                    <div className="text-muted-foreground/35 truncate mt-0.5">
                       {pathItem}
                     </div>
                   </div>
@@ -286,10 +282,10 @@ const DataImport = memo(() => {
               </div>
               <Button
                 type="button"
-                variant="outline"
+                variant="ghost"
                 size="sm"
                 onClick={() => setSelectedPaths([])}
-                className="text-xs"
+                className="text-xs text-muted-foreground/50"
               >
                 選択をクリア
               </Button>
@@ -327,20 +323,19 @@ const DataImport = memo(() => {
       </div>
 
       {/* インポート履歴・ロールバック */}
-      <div className="pt-8">
-        <div className="flex items-center justify-between mb-4">
-          <h4
-            className={`${TYPOGRAPHY.heading.tertiary} ${TEXT_COLOR.primary}`}
-          >
+      <div className="pt-12">
+        <div className="flex items-center justify-between mb-8">
+          <h4 className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground/35">
             インポート履歴・ロールバック
           </h4>
           <Button
-            variant="outline"
+            variant="ghost"
             size="sm"
             onClick={() => void refetchHistory()}
             disabled={isLoadingHistory}
+            className="text-muted-foreground/40 hover:text-foreground"
           >
-            <RotateCcw className="h-4 w-4 mr-2" />
+            <RotateCcw className="h-3.5 w-3.5 mr-2" />
             更新
           </Button>
         </div>

--- a/src/v2/components/settings/DataImport.tsx
+++ b/src/v2/components/settings/DataImport.tsx
@@ -230,9 +230,7 @@ const DataImport = memo(() => {
           {/* ドロップエリア */}
           <div
             className={`border-2 border-dashed rounded-lg p-6 text-center transition-colors ${
-              isDragOver
-                ? 'border-primary bg-primary/10 dark:bg-primary/20'
-                : 'border-border'
+              isDragOver ? 'border-primary bg-primary/10' : 'border-border'
             }`}
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}

--- a/src/v2/components/settings/DataImport.tsx
+++ b/src/v2/components/settings/DataImport.tsx
@@ -220,7 +220,7 @@ const DataImport = memo(() => {
       <div className="space-y-10">
         {/* ファイル選択・ドロップエリア */}
         <div className="space-y-5">
-          <Label className="text-[12px] text-muted-foreground/45">
+          <Label className="text-[12px] text-muted-foreground">
             インポートファイル
           </Label>
 
@@ -233,8 +233,8 @@ const DataImport = memo(() => {
             onDragLeave={handleDragLeave}
             onDrop={handleDrop}
           >
-            <Upload className="h-6 w-6 mx-auto mb-4 text-muted-foreground/25" />
-            <p className="text-[12px] text-muted-foreground/40 mb-5 leading-relaxed">
+            <Upload className="h-6 w-6 mx-auto mb-4 text-muted-foreground/60" />
+            <p className="text-[12px] text-muted-foreground mb-5 leading-relaxed">
               logStoreファイルやディレクトリをドラッグ&amp;ドロップするか、下のボタンで選択してください
             </p>
             <div className="flex gap-3 justify-center">
@@ -264,7 +264,7 @@ const DataImport = memo(() => {
           {/* 選択されたパス一覧 */}
           {selectedPaths.length > 0 && (
             <div className="space-y-4">
-              <Label className="text-[12px] text-muted-foreground/45">
+              <Label className="text-[12px] text-muted-foreground">
                 選択されたアイテム ({selectedPaths.length}個)
               </Label>
               <div className="max-h-32 overflow-y-auto space-y-2">
@@ -274,7 +274,7 @@ const DataImport = memo(() => {
                     className="text-[12px] text-foreground/70 bg-muted/20 px-4 py-3 rounded-xl"
                   >
                     {getFilenameFromPath(pathItem)}
-                    <div className="text-muted-foreground/35 truncate mt-0.5">
+                    <div className="text-muted-foreground/70 truncate mt-0.5">
                       {pathItem}
                     </div>
                   </div>
@@ -325,7 +325,7 @@ const DataImport = memo(() => {
       {/* インポート履歴・ロールバック */}
       <div className="pt-12">
         <div className="flex items-center justify-between mb-8">
-          <h4 className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground/35">
+          <h4 className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground/70">
             インポート履歴・ロールバック
           </h4>
           <Button
@@ -333,7 +333,7 @@ const DataImport = memo(() => {
             size="sm"
             onClick={() => void refetchHistory()}
             disabled={isLoadingHistory}
-            className="text-muted-foreground/40 hover:text-foreground"
+            className="text-muted-foreground hover:text-foreground"
           >
             <RotateCcw className="h-3.5 w-3.5 mr-2" />
             更新

--- a/src/v2/components/settings/DataImport.tsx
+++ b/src/v2/components/settings/DataImport.tsx
@@ -220,7 +220,7 @@ const DataImport = memo(() => {
       <div className="space-y-10">
         {/* ファイル選択・ドロップエリア */}
         <div className="space-y-5">
-          <Label className="text-[12px] text-muted-foreground">
+          <Label className="text-sm text-muted-foreground">
             インポートファイル
           </Label>
 
@@ -234,7 +234,7 @@ const DataImport = memo(() => {
             onDrop={handleDrop}
           >
             <Upload className="h-6 w-6 mx-auto mb-4 text-muted-foreground/60" />
-            <p className="text-[12px] text-muted-foreground mb-5 leading-relaxed">
+            <p className="text-sm text-muted-foreground mb-5 leading-relaxed">
               logStoreファイルやディレクトリをドラッグ&amp;ドロップするか、下のボタンで選択してください
             </p>
             <div className="flex gap-3 justify-center">
@@ -264,14 +264,14 @@ const DataImport = memo(() => {
           {/* 選択されたパス一覧 */}
           {selectedPaths.length > 0 && (
             <div className="space-y-4">
-              <Label className="text-[12px] text-muted-foreground">
+              <Label className="text-sm text-muted-foreground">
                 選択されたアイテム ({selectedPaths.length}個)
               </Label>
               <div className="max-h-32 overflow-y-auto space-y-2">
                 {selectedPaths.map((pathItem) => (
                   <div
                     key={pathItem}
-                    className="text-[12px] text-foreground/70 bg-muted/20 px-4 py-3 rounded-xl"
+                    className="text-sm text-foreground/70 bg-muted/20 px-4 py-3 rounded-xl"
                   >
                     {getFilenameFromPath(pathItem)}
                     <div className="text-muted-foreground/70 truncate mt-0.5">
@@ -325,7 +325,7 @@ const DataImport = memo(() => {
       {/* インポート履歴・ロールバック */}
       <div className="pt-12">
         <div className="flex items-center justify-between mb-8">
-          <h4 className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground/70">
+          <h4 className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground/70">
             インポート履歴・ロールバック
           </h4>
           <Button

--- a/src/v2/components/settings/DataImport.tsx
+++ b/src/v2/components/settings/DataImport.tsx
@@ -17,7 +17,6 @@ import { Label } from '../../../components/ui/label';
 import {
   SPACING,
   STATUS_BADGE,
-  SURFACE_COLOR,
   TEXT_COLOR,
   TYPOGRAPHY,
 } from '../../constants/ui';
@@ -229,8 +228,8 @@ const DataImport = memo(() => {
 
           {/* ドロップエリア */}
           <div
-            className={`border-2 border-dashed rounded-lg p-6 text-center transition-colors ${
-              isDragOver ? 'border-primary bg-primary/10' : 'border-border'
+            className={`rounded-2xl p-8 text-center transition-all duration-200 ease-spring ${
+              isDragOver ? 'bg-primary/8 scale-[1.01]' : 'bg-muted/30'
             }`}
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
@@ -328,7 +327,7 @@ const DataImport = memo(() => {
       </div>
 
       {/* インポート履歴・ロールバック */}
-      <div className="border-t border-border pt-6">
+      <div className="pt-8">
         <div className="flex items-center justify-between mb-4">
           <h4
             className={`${TYPOGRAPHY.heading.tertiary} ${TEXT_COLOR.primary}`}
@@ -362,7 +361,7 @@ const DataImport = memo(() => {
                 {importHistory.map((backup) => (
                   <div
                     key={backup.id}
-                    className={`flex items-center justify-between p-4 border border-border rounded-lg ${SURFACE_COLOR.muted}`}
+                    className="flex items-center justify-between p-4 rounded-xl bg-muted/30"
                   >
                     <div className="flex-1">
                       <div className="flex items-center space-x-2 mb-1">

--- a/src/v2/components/settings/DataImport.tsx
+++ b/src/v2/components/settings/DataImport.tsx
@@ -21,7 +21,7 @@ import {
   TYPOGRAPHY,
 } from '../../constants/ui';
 import { useToast } from '../../hooks/use-toast';
-import { SettingsInfoBox, SettingsSection } from './common';
+import { SettingsField, SettingsInfoBox, SettingsSection } from './common';
 
 // Note: ImportHistoryItem interface is used for documentation purposes
 // The actual type comes from the tRPC query result
@@ -219,11 +219,7 @@ const DataImport = memo(() => {
     >
       <div className="space-y-10">
         {/* ファイル選択・ドロップエリア */}
-        <div className="space-y-6">
-          <Label className="text-sm text-muted-foreground">
-            インポートファイル
-          </Label>
-
+        <SettingsField label="インポートファイル">
           {/* ドロップエリア — ボーダーなし、背景だけ */}
           <div
             className={`rounded-2xl py-12 px-8 text-center transition-all duration-200 ease-spring ${
@@ -291,7 +287,7 @@ const DataImport = memo(() => {
               </Button>
             </div>
           )}
-        </div>
+        </SettingsField>
 
         {/* インポートボタン */}
         <div className="pt-4">

--- a/src/v2/components/settings/LicenseInfo.tsx
+++ b/src/v2/components/settings/LicenseInfo.tsx
@@ -3,7 +3,6 @@ import { memo } from 'react';
 
 import licenseJsonFile from '@/assets/licenses.json';
 
-import { TEXT_COLOR, TYPOGRAPHY } from '../../constants/ui';
 import { useI18n } from '../../i18n/store';
 import { SettingsSection } from './common';
 
@@ -37,29 +36,30 @@ const LicenseInfo = memo(() => {
 
   return (
     <SettingsSection icon={Book} title={t('settings.info.licenses.title')}>
-      <div className="divide-y divide-border">
+      <div className="space-y-1">
         {libraries.map((lib) => (
-          <div key={lib.path} className="py-3">
-            <div className="flex items-center justify-between mb-1">
-              <span
-                className={`${TYPOGRAPHY.body.emphasis} ${TEXT_COLOR.primary}`}
-              >
+          <div
+            key={lib.path}
+            className="py-2.5 px-3 rounded-lg hover:bg-muted/30 transition-colors duration-150"
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium text-foreground">
                 {lib.name}
               </span>
-              <span className={`${TYPOGRAPHY.body.small} ${TEXT_COLOR.muted}`}>
+              <span className="text-xs text-muted-foreground/50">
                 {lib.licenses}
               </span>
             </div>
             {lib.repository && (
-              <div
-                className={`flex items-center justify-between ${TYPOGRAPHY.body.small}`}
-              >
-                <span className={TEXT_COLOR.secondary}>Repository</span>
+              <div className="flex items-center justify-between mt-0.5">
+                <span className="text-xs text-muted-foreground/40">
+                  Repository
+                </span>
                 <a
                   href={lib.repository}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-primary hover:text-primary/80"
+                  className="text-xs text-primary/70 hover:text-primary transition-colors"
                 >
                   {lib.repository}
                 </a>

--- a/src/v2/components/settings/LicenseInfo.tsx
+++ b/src/v2/components/settings/LicenseInfo.tsx
@@ -46,13 +46,13 @@ const LicenseInfo = memo(() => {
               <span className="text-sm font-medium text-foreground">
                 {lib.name}
               </span>
-              <span className="text-xs text-muted-foreground/50">
+              <span className="text-xs text-muted-foreground">
                 {lib.licenses}
               </span>
             </div>
             {lib.repository && (
               <div className="flex items-center justify-between mt-0.5">
-                <span className="text-xs text-muted-foreground/40">
+                <span className="text-xs text-muted-foreground">
                   Repository
                 </span>
                 <a

--- a/src/v2/components/settings/PathSettings.tsx
+++ b/src/v2/components/settings/PathSettings.tsx
@@ -257,7 +257,6 @@ const PathSettingsComponent = memo(({ showRefreshAll }: PathSettingsProps) => {
           saveLabel={`${t('common.submit')}-${t('settings.paths.logFile')}`}
         />
 
-        {/* Refresh All Section — 余白で区切り、ボーダーなし */}
         {showRefreshAll && (
           <div className="pt-6">
             <div className="space-y-5">

--- a/src/v2/components/settings/PathSettings.tsx
+++ b/src/v2/components/settings/PathSettings.tsx
@@ -6,12 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { trpcReact } from '@/trpc';
 
-import {
-  SPACING,
-  SURFACE_COLOR,
-  TEXT_COLOR,
-  TYPOGRAPHY,
-} from '../../constants/ui';
+import { SPACING, TEXT_COLOR, TYPOGRAPHY } from '../../constants/ui';
 import { useInitProgress } from '../../hooks/useInitProgress';
 import { LOG_SYNC_MODE, useLogSync } from '../../hooks/useLogSync';
 import { useVRChatPhotoExtraDirList } from '../../hooks/useVRChatPhotoExtraDirList';
@@ -203,124 +198,118 @@ const PathSettingsComponent = memo(({ showRefreshAll }: PathSettingsProps) => {
 
   return (
     <SettingsSection icon={FolderOpen} title="パス設定">
-      <div
-        className={`${SURFACE_COLOR.muted} rounded-lg ${SPACING.padding.card}`}
-      >
-        <div className={SPACING.stack.relaxed}>
-          {/* Photo Directory Section */}
-          <SettingsPathInput
-            label={t('settings.paths.photoDirectory')}
-            value={photoInputValue}
-            onChange={handlePhotoInputChange}
-            onBrowse={() => void handleBrowsePhotoDirectory()}
-            onSave={() => void handlePhotoPathSave()}
-            isManuallyChanged={isPhotoPathManuallyChanged}
-            error={photoValidationErrorMessage}
-            placeholder="/path/to/photos"
-            browseLabel={`${t('settings.paths.browse')}-${t('settings.paths.photoDirectory')}`}
-            saveLabel={`${t('common.submit')}-${t('settings.paths.photoDirectory')}`}
-          />
+      <div className={SPACING.stack.relaxed}>
+        {/* Photo Directory Section */}
+        <SettingsPathInput
+          label={t('settings.paths.photoDirectory')}
+          value={photoInputValue}
+          onChange={handlePhotoInputChange}
+          onBrowse={() => void handleBrowsePhotoDirectory()}
+          onSave={() => void handlePhotoPathSave()}
+          isManuallyChanged={isPhotoPathManuallyChanged}
+          error={photoValidationErrorMessage}
+          placeholder="/path/to/photos"
+          browseLabel={`${t('settings.paths.browse')}-${t('settings.paths.photoDirectory')}`}
+          saveLabel={`${t('common.submit')}-${t('settings.paths.photoDirectory')}`}
+        />
 
-          {/* Extra Directories */}
+        {/* Extra Directories */}
+        <div className={SPACING.stack.default}>
+          <span
+            className={`${TYPOGRAPHY.body.emphasis} ${TEXT_COLOR.secondary}`}
+          >
+            追加で読み込ませる写真フォルダ
+          </span>
           <div className={SPACING.stack.default}>
-            <span
-              className={`${TYPOGRAPHY.body.emphasis} ${TEXT_COLOR.secondary}`}
-            >
-              追加で読み込ませる写真フォルダ
-            </span>
-            <div className={SPACING.stack.default}>
-              {extraDirs.map((dir: string, index: number) => (
-                <div key={`extra-dir-${dir}`} className="flex gap-2">
-                  <Input type="text" value={dir} readOnly className="flex-1" />
-                  <Button
-                    type="button"
-                    onClick={() => handleRemoveExtraDirectory(index)}
-                    aria-label={t('settings.paths.removeExtraDirectory')}
-                    variant="secondary"
-                    size="sm"
-                  >
-                    <Trash className="h-4 w-4" />
-                  </Button>
-                </div>
-              ))}
-              <Button
-                type="button"
-                onClick={() => void handleBrowseExtraDirectory()}
-                aria-label={t('settings.paths.addExtraDirectory')}
-                variant="secondary"
-                size="sm"
-                className="w-full"
-              >
-                <Plus className="h-4 w-4 mr-2" />
-                フォルダを追加
-              </Button>
-            </div>
-          </div>
-
-          {/* Log File Section */}
-          <SettingsPathInput
-            label={t('settings.paths.logFile')}
-            value={logInputValue}
-            onChange={handleLogInputChange}
-            onBrowse={() => void handleBrowseLogFile()}
-            onSave={() => void handleLogPathSave()}
-            isManuallyChanged={isLogPathManuallyChanged}
-            error={logValidationErrorMessage}
-            placeholder="/path/to/photo-logs.json"
-            browseLabel={`${t('settings.paths.browse')}-${t('settings.paths.logFile')}`}
-            saveLabel={`${t('common.submit')}-${t('settings.paths.logFile')}`}
-          />
-
-          {/* Refresh All Section */}
-          {showRefreshAll && (
-            <div className="pt-4 border-t border-border">
-              <div className={SPACING.stack.default}>
-                <p
-                  className={`${TYPOGRAPHY.body.small} ${TEXT_COLOR.secondary}`}
+            {extraDirs.map((dir: string, index: number) => (
+              <div key={`extra-dir-${dir}`} className="flex gap-2">
+                <Input type="text" value={dir} readOnly className="flex-1" />
+                <Button
+                  type="button"
+                  onClick={() => handleRemoveExtraDirectory(index)}
+                  aria-label={t('settings.paths.removeExtraDirectory')}
+                  variant="secondary"
+                  size="sm"
                 >
-                  設定したVRChatのログファイルから、過去のワールド訪問履歴を含む全てのインデックスを再構築します。
-                  初回設定時や、インデックスの不整合が発生した場合に使用してください。
-                </p>
-                {isRefreshing && (
-                  <div className={SPACING.stack.tight}>
-                    <div className="h-1.5 bg-muted rounded-full overflow-hidden">
-                      <div
-                        className="h-full bg-primary transition-all duration-300 ease-out rounded-full"
-                        style={{
-                          width: `${Math.max(progress?.progress ?? 0, 5)}%`,
-                        }}
-                      />
-                    </div>
-                    <p
-                      className={`${TYPOGRAPHY.caption.default} ${TEXT_COLOR.secondary}`}
-                    >
-                      {progressMessage || t('pullToRefresh.refreshing')}
-                      {progress?.details?.current !== null &&
-                        progress?.details?.current !== undefined &&
-                        progress?.details?.total !== null &&
-                        progress?.details?.total !== undefined &&
-                        ` (${progress.details.current}/${progress.details.total})`}
-                    </p>
-                  </div>
-                )}
-                <div className="flex justify-end">
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    onClick={() => void handleRefreshAll()}
-                    disabled={isRefreshing}
-                    aria-label={t('common.refresh')}
-                  >
-                    <RefreshCw
-                      className={`h-4 w-4 mr-2 ${isRefreshing ? 'animate-spin' : ''}`}
+                  <Trash className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+            <Button
+              type="button"
+              onClick={() => void handleBrowseExtraDirectory()}
+              aria-label={t('settings.paths.addExtraDirectory')}
+              variant="secondary"
+              size="sm"
+              className="w-full"
+            >
+              <Plus className="h-4 w-4 mr-2" />
+              フォルダを追加
+            </Button>
+          </div>
+        </div>
+
+        {/* Log File Section */}
+        <SettingsPathInput
+          label={t('settings.paths.logFile')}
+          value={logInputValue}
+          onChange={handleLogInputChange}
+          onBrowse={() => void handleBrowseLogFile()}
+          onSave={() => void handleLogPathSave()}
+          isManuallyChanged={isLogPathManuallyChanged}
+          error={logValidationErrorMessage}
+          placeholder="/path/to/photo-logs.json"
+          browseLabel={`${t('settings.paths.browse')}-${t('settings.paths.logFile')}`}
+          saveLabel={`${t('common.submit')}-${t('settings.paths.logFile')}`}
+        />
+
+        {/* Refresh All Section — 余白で区切り、ボーダーなし */}
+        {showRefreshAll && (
+          <div className="pt-4">
+            <div className={SPACING.stack.default}>
+              <p className={`${TYPOGRAPHY.body.small} ${TEXT_COLOR.secondary}`}>
+                設定したVRChatのログファイルから、過去のワールド訪問履歴を含む全てのインデックスを再構築します。
+                初回設定時や、インデックスの不整合が発生した場合に使用してください。
+              </p>
+              {isRefreshing && (
+                <div className={SPACING.stack.tight}>
+                  <div className="h-1.5 bg-muted rounded-full overflow-hidden">
+                    <div
+                      className="h-full bg-primary transition-all duration-300 ease-out rounded-full"
+                      style={{
+                        width: `${Math.max(progress?.progress ?? 0, 5)}%`,
+                      }}
                     />
-                    {t('common.refresh')}
-                  </Button>
+                  </div>
+                  <p
+                    className={`${TYPOGRAPHY.caption.default} ${TEXT_COLOR.secondary}`}
+                  >
+                    {progressMessage || t('pullToRefresh.refreshing')}
+                    {progress?.details?.current !== null &&
+                      progress?.details?.current !== undefined &&
+                      progress?.details?.total !== null &&
+                      progress?.details?.total !== undefined &&
+                      ` (${progress.details.current}/${progress.details.total})`}
+                  </p>
                 </div>
+              )}
+              <div className="flex justify-end">
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => void handleRefreshAll()}
+                  disabled={isRefreshing}
+                  aria-label={t('common.refresh')}
+                >
+                  <RefreshCw
+                    className={`h-4 w-4 mr-2 ${isRefreshing ? 'animate-spin' : ''}`}
+                  />
+                  {t('common.refresh')}
+                </Button>
               </div>
             </div>
-          )}
-        </div>
+          </div>
+        )}
       </div>
     </SettingsSection>
   );

--- a/src/v2/components/settings/PathSettings.tsx
+++ b/src/v2/components/settings/PathSettings.tsx
@@ -6,7 +6,6 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { trpcReact } from '@/trpc';
 
-import { SPACING, TEXT_COLOR, TYPOGRAPHY } from '../../constants/ui';
 import { useInitProgress } from '../../hooks/useInitProgress';
 import { LOG_SYNC_MODE, useLogSync } from '../../hooks/useLogSync';
 import { useVRChatPhotoExtraDirList } from '../../hooks/useVRChatPhotoExtraDirList';
@@ -198,7 +197,7 @@ const PathSettingsComponent = memo(({ showRefreshAll }: PathSettingsProps) => {
 
   return (
     <SettingsSection icon={FolderOpen} title="パス設定">
-      <div className={SPACING.stack.relaxed}>
+      <div className="space-y-10">
         {/* Photo Directory Section */}
         <SettingsPathInput
           label={t('settings.paths.photoDirectory')}
@@ -214,13 +213,11 @@ const PathSettingsComponent = memo(({ showRefreshAll }: PathSettingsProps) => {
         />
 
         {/* Extra Directories */}
-        <div className={SPACING.stack.default}>
-          <span
-            className={`${TYPOGRAPHY.body.emphasis} ${TEXT_COLOR.secondary}`}
-          >
+        <div className="space-y-4">
+          <span className="text-[12px] text-muted-foreground/45">
             追加で読み込ませる写真フォルダ
           </span>
-          <div className={SPACING.stack.default}>
+          <div className="space-y-3">
             {extraDirs.map((dir: string, index: number) => (
               <div key={`extra-dir-${dir}`} className="flex gap-2">
                 <Input type="text" value={dir} readOnly className="flex-1" />
@@ -265,25 +262,23 @@ const PathSettingsComponent = memo(({ showRefreshAll }: PathSettingsProps) => {
 
         {/* Refresh All Section — 余白で区切り、ボーダーなし */}
         {showRefreshAll && (
-          <div className="pt-4">
-            <div className={SPACING.stack.default}>
-              <p className={`${TYPOGRAPHY.body.small} ${TEXT_COLOR.secondary}`}>
+          <div className="pt-6">
+            <div className="space-y-5">
+              <p className="text-[12px] text-muted-foreground/45 leading-relaxed max-w-lg">
                 設定したVRChatのログファイルから、過去のワールド訪問履歴を含む全てのインデックスを再構築します。
                 初回設定時や、インデックスの不整合が発生した場合に使用してください。
               </p>
               {isRefreshing && (
-                <div className={SPACING.stack.tight}>
-                  <div className="h-1.5 bg-muted rounded-full overflow-hidden">
+                <div className="space-y-3">
+                  <div className="h-0.5 bg-muted/40 rounded-full overflow-hidden">
                     <div
-                      className="h-full bg-primary transition-all duration-300 ease-out rounded-full"
+                      className="h-full bg-primary/60 transition-all duration-500 ease-spring rounded-full"
                       style={{
                         width: `${Math.max(progress?.progress ?? 0, 5)}%`,
                       }}
                     />
                   </div>
-                  <p
-                    className={`${TYPOGRAPHY.caption.default} ${TEXT_COLOR.secondary}`}
-                  >
+                  <p className="text-[11px] text-muted-foreground/40">
                     {progressMessage || t('pullToRefresh.refreshing')}
                     {progress?.details?.current !== null &&
                       progress?.details?.current !== undefined &&

--- a/src/v2/components/settings/PathSettings.tsx
+++ b/src/v2/components/settings/PathSettings.tsx
@@ -214,7 +214,7 @@ const PathSettingsComponent = memo(({ showRefreshAll }: PathSettingsProps) => {
 
         {/* Extra Directories */}
         <div className="space-y-4">
-          <span className="text-[12px] text-muted-foreground">
+          <span className="text-sm text-muted-foreground">
             追加で読み込ませる写真フォルダ
           </span>
           <div className="space-y-3">
@@ -264,7 +264,7 @@ const PathSettingsComponent = memo(({ showRefreshAll }: PathSettingsProps) => {
         {showRefreshAll && (
           <div className="pt-6">
             <div className="space-y-5">
-              <p className="text-[12px] text-muted-foreground leading-relaxed max-w-lg">
+              <p className="text-sm text-muted-foreground leading-relaxed max-w-lg">
                 設定したVRChatのログファイルから、過去のワールド訪問履歴を含む全てのインデックスを再構築します。
                 初回設定時や、インデックスの不整合が発生した場合に使用してください。
               </p>
@@ -278,7 +278,7 @@ const PathSettingsComponent = memo(({ showRefreshAll }: PathSettingsProps) => {
                       }}
                     />
                   </div>
-                  <p className="text-[11px] text-muted-foreground">
+                  <p className="text-xs text-muted-foreground">
                     {progressMessage || t('pullToRefresh.refreshing')}
                     {progress?.details?.current !== null &&
                       progress?.details?.current !== undefined &&

--- a/src/v2/components/settings/PathSettings.tsx
+++ b/src/v2/components/settings/PathSettings.tsx
@@ -214,7 +214,7 @@ const PathSettingsComponent = memo(({ showRefreshAll }: PathSettingsProps) => {
 
         {/* Extra Directories */}
         <div className="space-y-4">
-          <span className="text-[12px] text-muted-foreground/45">
+          <span className="text-[12px] text-muted-foreground">
             追加で読み込ませる写真フォルダ
           </span>
           <div className="space-y-3">
@@ -264,7 +264,7 @@ const PathSettingsComponent = memo(({ showRefreshAll }: PathSettingsProps) => {
         {showRefreshAll && (
           <div className="pt-6">
             <div className="space-y-5">
-              <p className="text-[12px] text-muted-foreground/45 leading-relaxed max-w-lg">
+              <p className="text-[12px] text-muted-foreground leading-relaxed max-w-lg">
                 設定したVRChatのログファイルから、過去のワールド訪問履歴を含む全てのインデックスを再構築します。
                 初回設定時や、インデックスの不整合が発生した場合に使用してください。
               </p>
@@ -278,7 +278,7 @@ const PathSettingsComponent = memo(({ showRefreshAll }: PathSettingsProps) => {
                       }}
                     />
                   </div>
-                  <p className="text-[11px] text-muted-foreground/40">
+                  <p className="text-[11px] text-muted-foreground">
                     {progressMessage || t('pullToRefresh.refreshing')}
                     {progress?.details?.current !== null &&
                       progress?.details?.current !== undefined &&

--- a/src/v2/components/settings/PathSettings.tsx
+++ b/src/v2/components/settings/PathSettings.tsx
@@ -213,7 +213,7 @@ const PathSettingsComponent = memo(({ showRefreshAll }: PathSettingsProps) => {
         />
 
         {/* Extra Directories */}
-        <div className="space-y-4">
+        <div className="space-y-6">
           <span className="text-sm text-muted-foreground">
             追加で読み込ませる写真フォルダ
           </span>

--- a/src/v2/components/settings/PathSettings.tsx
+++ b/src/v2/components/settings/PathSettings.tsx
@@ -10,7 +10,7 @@ import { useInitProgress } from '../../hooks/useInitProgress';
 import { LOG_SYNC_MODE, useLogSync } from '../../hooks/useLogSync';
 import { useVRChatPhotoExtraDirList } from '../../hooks/useVRChatPhotoExtraDirList';
 import { useI18n } from '../../i18n/store';
-import { SettingsPathInput, SettingsSection } from './common';
+import { SettingsField, SettingsPathInput, SettingsSection } from './common';
 
 interface PathSettingsProps {
   showRefreshAll: boolean;
@@ -213,11 +213,8 @@ const PathSettingsComponent = memo(({ showRefreshAll }: PathSettingsProps) => {
         />
 
         {/* Extra Directories */}
-        <div className="space-y-6">
-          <span className="text-sm text-muted-foreground">
-            追加で読み込ませる写真フォルダ
-          </span>
-          <div className="space-y-3">
+        <SettingsField label="追加で読み込ませる写真フォルダ">
+          <div className="flex flex-col gap-3">
             {extraDirs.map((dir: string, index: number) => (
               <div key={`extra-dir-${dir}`} className="flex gap-2">
                 <Input type="text" value={dir} readOnly className="flex-1" />
@@ -244,7 +241,7 @@ const PathSettingsComponent = memo(({ showRefreshAll }: PathSettingsProps) => {
               フォルダを追加
             </Button>
           </div>
-        </div>
+        </SettingsField>
 
         {/* Log File Section */}
         <SettingsPathInput

--- a/src/v2/components/settings/SettingsModal.tsx
+++ b/src/v2/components/settings/SettingsModal.tsx
@@ -118,7 +118,7 @@ const SettingsModal = memo(({ onClose }: SettingsModalProps) => {
       <DialogContent className="h-[85vh] w-[880px] max-w-[880px] p-0 overflow-hidden">
         {/* ヘッダー — 圧倒的余白の中にタイトルだけ */}
         <DialogHeader className="px-14 pt-14 pb-4">
-          <DialogTitle className="text-lg font-medium tracking-tight text-foreground/80">
+          <DialogTitle className="text-lg font-medium tracking-tight text-foreground">
             {t('common.settings')}
           </DialogTitle>
         </DialogHeader>
@@ -138,10 +138,10 @@ const SettingsModal = memo(({ onClose }: SettingsModalProps) => {
                   className={`relative py-2 px-3 flex items-center text-[13px] transition-all duration-200 ease-spring rounded-lg ${
                     activeTab === id
                       ? 'text-foreground bg-muted/40'
-                      : 'text-muted-foreground/50 hover:text-foreground/80 hover:bg-muted/20'
+                      : 'text-muted-foreground hover:text-foreground hover:bg-muted/20'
                   }`}
                 >
-                  <Icon className="h-[14px] w-[14px] mr-3 flex-shrink-0 opacity-40" />
+                  <Icon className="h-[14px] w-[14px] mr-3 flex-shrink-0 opacity-60" />
                   <span className="truncate">{label}</span>
                 </button>
               ))}

--- a/src/v2/components/settings/SettingsModal.tsx
+++ b/src/v2/components/settings/SettingsModal.tsx
@@ -115,19 +115,19 @@ const SettingsModal = memo(({ onClose }: SettingsModalProps) => {
 
   return (
     <Dialog open onOpenChange={() => onClose()}>
-      <DialogContent className="h-[85vh] w-[840px] max-w-[840px] p-0 overflow-hidden">
-        {/* ヘッダー — ミニマル、余白で存在感 */}
-        <DialogHeader className="px-10 pt-10 pb-4">
+      <DialogContent className="h-[85vh] w-[860px] max-w-[860px] p-0 overflow-hidden">
+        {/* ヘッダー — たっぷりの余白で「設定」の一語だけが静かに存在 */}
+        <DialogHeader className="px-12 pt-12 pb-6">
           <DialogTitle className="text-xl font-semibold tracking-tight">
             {t('common.settings')}
           </DialogTitle>
         </DialogHeader>
 
-        <div className="flex-1 flex h-[calc(85vh-90px)]">
-          {/* サイドバー — 広い余白、ゆったりしたタブ */}
+        <div className="flex-1 flex h-[calc(85vh-100px)]">
+          {/* サイドバー — Arc風：ゆったり、各タブ間に余裕 */}
           <div className="flex-none w-52">
             <nav
-              className="flex flex-col px-5 py-3 space-y-0.5"
+              className="flex flex-col px-6 py-2 space-y-1"
               aria-label="Tabs"
             >
               {tabs.map(({ id, label, icon: Icon }) => (
@@ -135,21 +135,21 @@ const SettingsModal = memo(({ onClose }: SettingsModalProps) => {
                   type="button"
                   key={id}
                   onClick={() => setActiveTab(id)}
-                  className={`relative py-2.5 px-4 flex items-center text-[13px] font-medium transition-all duration-200 ease-spring rounded-xl ${
+                  className={`relative py-2 px-3 flex items-center text-[13px] transition-all duration-200 ease-spring rounded-lg ${
                     activeTab === id
-                      ? 'text-foreground bg-muted/60'
-                      : 'text-muted-foreground/70 hover:text-foreground hover:bg-muted/30'
+                      ? 'text-foreground font-medium bg-muted/50'
+                      : 'text-muted-foreground/60 hover:text-foreground hover:bg-muted/25'
                   }`}
                 >
-                  <Icon className="h-4 w-4 mr-3.5 flex-shrink-0 opacity-60" />
+                  <Icon className="h-[15px] w-[15px] mr-3 flex-shrink-0 opacity-50" />
                   <span className="truncate">{label}</span>
                 </button>
               ))}
             </nav>
           </div>
 
-          {/* コンテンツ — 広大な余白でエレガントに */}
-          <div className="flex-1 overflow-y-auto px-10 py-6">
+          {/* コンテンツ — 圧倒的な余白。Arc のように内容が空間に浮いている感覚 */}
+          <div className="flex-1 overflow-y-auto px-12 py-8">
             <ActiveComponent />
           </div>
         </div>

--- a/src/v2/components/settings/SettingsModal.tsx
+++ b/src/v2/components/settings/SettingsModal.tsx
@@ -135,7 +135,7 @@ const SettingsModal = memo(({ onClose }: SettingsModalProps) => {
                   type="button"
                   key={id}
                   onClick={() => setActiveTab(id)}
-                  className={`relative py-2 px-3 flex items-center text-[13px] transition-all duration-200 ease-spring rounded-lg ${
+                  className={`relative py-2 px-3 flex items-center text-sm transition-all duration-200 ease-spring rounded-lg ${
                     activeTab === id
                       ? 'text-foreground bg-muted/40'
                       : 'text-muted-foreground hover:text-foreground hover:bg-muted/20'

--- a/src/v2/components/settings/SettingsModal.tsx
+++ b/src/v2/components/settings/SettingsModal.tsx
@@ -115,19 +115,19 @@ const SettingsModal = memo(({ onClose }: SettingsModalProps) => {
 
   return (
     <Dialog open onOpenChange={() => onClose()}>
-      <DialogContent className="h-[85vh] w-[860px] max-w-[860px] p-0 overflow-hidden">
-        {/* ヘッダー — たっぷりの余白で「設定」の一語だけが静かに存在 */}
-        <DialogHeader className="px-12 pt-12 pb-6">
-          <DialogTitle className="text-xl font-semibold tracking-tight">
+      <DialogContent className="h-[85vh] w-[880px] max-w-[880px] p-0 overflow-hidden">
+        {/* ヘッダー — 圧倒的余白の中にタイトルだけ */}
+        <DialogHeader className="px-14 pt-14 pb-4">
+          <DialogTitle className="text-lg font-medium tracking-tight text-foreground/80">
             {t('common.settings')}
           </DialogTitle>
         </DialogHeader>
 
         <div className="flex-1 flex h-[calc(85vh-100px)]">
-          {/* サイドバー — Arc風：ゆったり、各タブ間に余裕 */}
-          <div className="flex-none w-52">
+          {/* サイドバー — 広い余白、タブ間にゆとり */}
+          <div className="flex-none w-56">
             <nav
-              className="flex flex-col px-6 py-2 space-y-1"
+              className="flex flex-col px-7 pt-4 space-y-0.5"
               aria-label="Tabs"
             >
               {tabs.map(({ id, label, icon: Icon }) => (
@@ -137,19 +137,19 @@ const SettingsModal = memo(({ onClose }: SettingsModalProps) => {
                   onClick={() => setActiveTab(id)}
                   className={`relative py-2 px-3 flex items-center text-[13px] transition-all duration-200 ease-spring rounded-lg ${
                     activeTab === id
-                      ? 'text-foreground font-medium bg-muted/50'
-                      : 'text-muted-foreground/60 hover:text-foreground hover:bg-muted/25'
+                      ? 'text-foreground bg-muted/40'
+                      : 'text-muted-foreground/50 hover:text-foreground/80 hover:bg-muted/20'
                   }`}
                 >
-                  <Icon className="h-[15px] w-[15px] mr-3 flex-shrink-0 opacity-50" />
+                  <Icon className="h-[14px] w-[14px] mr-3 flex-shrink-0 opacity-40" />
                   <span className="truncate">{label}</span>
                 </button>
               ))}
             </nav>
           </div>
 
-          {/* コンテンツ — 圧倒的な余白。Arc のように内容が空間に浮いている感覚 */}
-          <div className="flex-1 overflow-y-auto px-12 py-8">
+          {/* コンテンツ — 空間の中に要素が浮いている */}
+          <div className="flex-1 overflow-y-auto px-14 py-10">
             <ActiveComponent />
           </div>
         </div>

--- a/src/v2/components/settings/SettingsModal.tsx
+++ b/src/v2/components/settings/SettingsModal.tsx
@@ -115,35 +115,41 @@ const SettingsModal = memo(({ onClose }: SettingsModalProps) => {
 
   return (
     <Dialog open onOpenChange={() => onClose()}>
-      <DialogContent className="h-[90vh] w-[800px] max-w-[800px] p-0 glass-panel">
-        <DialogHeader className="px-6 py-4 border-b border-border/40 backdrop-blur-sm">
-          <DialogTitle className="text-xl font-semibold">
+      <DialogContent className="h-[85vh] w-[840px] max-w-[840px] p-0 overflow-hidden">
+        {/* ヘッダー — ミニマル、余白で存在感 */}
+        <DialogHeader className="px-10 pt-10 pb-4">
+          <DialogTitle className="text-xl font-semibold tracking-tight">
             {t('common.settings')}
           </DialogTitle>
         </DialogHeader>
 
-        <div className="flex-1 flex h-[calc(90vh-80px)]">
-          <div className="flex-none w-48 border-r border-border/30">
-            <nav className="flex flex-col p-2" aria-label="Tabs">
+        <div className="flex-1 flex h-[calc(85vh-90px)]">
+          {/* サイドバー — 広い余白、ゆったりしたタブ */}
+          <div className="flex-none w-52">
+            <nav
+              className="flex flex-col px-5 py-3 space-y-0.5"
+              aria-label="Tabs"
+            >
               {tabs.map(({ id, label, icon: Icon }) => (
                 <button
                   type="button"
                   key={id}
                   onClick={() => setActiveTab(id)}
-                  className={`relative py-3 px-4 flex items-center text-sm font-medium transition-all duration-200 rounded-lg m-1 ${
+                  className={`relative py-2.5 px-4 flex items-center text-[13px] font-medium transition-all duration-200 ease-spring rounded-xl ${
                     activeTab === id
-                      ? 'text-primary bg-primary/8 shadow-sm'
-                      : 'text-muted-foreground hover:text-foreground hover:bg-muted/30'
+                      ? 'text-foreground bg-muted/60'
+                      : 'text-muted-foreground/70 hover:text-foreground hover:bg-muted/30'
                   }`}
                 >
-                  <Icon className="h-4 w-4 mr-3 flex-shrink-0" />
+                  <Icon className="h-4 w-4 mr-3.5 flex-shrink-0 opacity-60" />
                   <span className="truncate">{label}</span>
                 </button>
               ))}
             </nav>
           </div>
 
-          <div className="flex-1 overflow-y-auto p-6 bg-background/30 backdrop-blur-sm">
+          {/* コンテンツ — 広大な余白でエレガントに */}
+          <div className="flex-1 overflow-y-auto px-10 py-6">
             <ActiveComponent />
           </div>
         </div>

--- a/src/v2/components/settings/SystemSettings.tsx
+++ b/src/v2/components/settings/SystemSettings.tsx
@@ -78,7 +78,7 @@ const SystemSettings = memo(() => {
 
   return (
     <SettingsSection icon={Settings} title={t('settings.system.title')}>
-      <div className="space-y-4">
+      <div className="space-y-2">
         <SettingsItem
           label={t('settings.system.startupLaunch')}
           description={t('settings.system.startupDescription')}

--- a/src/v2/components/settings/ThemeSelector.tsx
+++ b/src/v2/components/settings/ThemeSelector.tsx
@@ -34,7 +34,7 @@ const ThemeSelector = memo(() => {
             className={cn(
               'flex items-center justify-center gap-2 p-3 rounded-lg border-2 transition-colors',
               theme === value
-                ? 'border-primary bg-primary/10 dark:bg-primary/20'
+                ? 'border-primary bg-primary/10'
                 : 'border-border hover:border-primary/50',
             )}
           >

--- a/src/v2/components/settings/ThemeSelector.tsx
+++ b/src/v2/components/settings/ThemeSelector.tsx
@@ -43,7 +43,7 @@ const ThemeSelector = memo(() => {
                 theme === value ? 'text-primary' : 'opacity-40',
               )}
             />
-            <span className="text-[13px] font-medium">{label}</span>
+            <span className="text-sm font-medium">{label}</span>
           </button>
         ))}
       </div>

--- a/src/v2/components/settings/ThemeSelector.tsx
+++ b/src/v2/components/settings/ThemeSelector.tsx
@@ -3,7 +3,6 @@ import { memo } from 'react';
 
 import { cn } from '@/components/lib/utils';
 
-import { TYPOGRAPHY } from '../../constants/ui';
 import { useTheme } from '../../hooks/useTheme';
 import { useI18n } from '../../i18n/store';
 import type { ThemeOption } from '../../utils/theme';
@@ -25,26 +24,26 @@ const ThemeSelector = memo(() => {
 
   return (
     <SettingsSection icon={Sun} title={t('settings.theme.title')}>
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
         {themeOptions.map(({ value, label, icon: Icon }) => (
           <button
             type="button"
             key={value}
             onClick={() => setTheme(value)}
             className={cn(
-              'flex items-center justify-center gap-2 p-3 rounded-xl transition-all duration-200 ease-spring',
+              'flex flex-col items-center justify-center gap-2.5 py-6 px-4 rounded-xl transition-all duration-200 ease-spring',
               theme === value
-                ? 'bg-muted/70 shadow-subtle text-foreground'
-                : 'text-muted-foreground hover:bg-muted/40 hover:text-foreground',
+                ? 'bg-muted/50 text-foreground'
+                : 'text-muted-foreground/50 hover:bg-muted/25 hover:text-foreground',
             )}
           >
             <Icon
               className={cn(
-                'h-4 w-4',
-                theme === value ? 'text-primary' : 'text-muted-foreground/50',
+                'h-5 w-5',
+                theme === value ? 'text-primary' : 'opacity-40',
               )}
             />
-            <span className={cn(TYPOGRAPHY.body.emphasis)}>{label}</span>
+            <span className="text-[13px] font-medium">{label}</span>
           </button>
         ))}
       </div>

--- a/src/v2/components/settings/ThemeSelector.tsx
+++ b/src/v2/components/settings/ThemeSelector.tsx
@@ -3,7 +3,7 @@ import { memo } from 'react';
 
 import { cn } from '@/components/lib/utils';
 
-import { TEXT_COLOR, TYPOGRAPHY } from '../../constants/ui';
+import { TYPOGRAPHY } from '../../constants/ui';
 import { useTheme } from '../../hooks/useTheme';
 import { useI18n } from '../../i18n/store';
 import type { ThemeOption } from '../../utils/theme';
@@ -25,33 +25,26 @@ const ThemeSelector = memo(() => {
 
   return (
     <SettingsSection icon={Sun} title={t('settings.theme.title')}>
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
         {themeOptions.map(({ value, label, icon: Icon }) => (
           <button
             type="button"
             key={value}
             onClick={() => setTheme(value)}
             className={cn(
-              'flex items-center justify-center gap-2 p-3 rounded-lg border-2 transition-colors',
+              'flex items-center justify-center gap-2 p-3 rounded-xl transition-all duration-200 ease-spring',
               theme === value
-                ? 'border-primary bg-primary/10'
-                : 'border-border hover:border-primary/50',
+                ? 'bg-muted/70 shadow-subtle text-foreground'
+                : 'text-muted-foreground hover:bg-muted/40 hover:text-foreground',
             )}
           >
             <Icon
               className={cn(
-                'h-5 w-5',
-                theme === value ? 'text-primary' : TEXT_COLOR.muted,
+                'h-4 w-4',
+                theme === value ? 'text-primary' : 'text-muted-foreground/50',
               )}
             />
-            <span
-              className={cn(
-                TYPOGRAPHY.body.emphasis,
-                theme === value ? 'text-primary' : TEXT_COLOR.secondary,
-              )}
-            >
-              {label}
-            </span>
+            <span className={cn(TYPOGRAPHY.body.emphasis)}>{label}</span>
           </button>
         ))}
       </div>

--- a/src/v2/components/settings/common/SettingsField.tsx
+++ b/src/v2/components/settings/common/SettingsField.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from 'react';
+import { memo } from 'react';
+
+import { cn } from '../../../../components/lib/utils';
+
+interface SettingsFieldProps {
+  /** フィールドラベル */
+  label: string;
+  /** ラベルの htmlFor（input の id と対応） */
+  htmlFor?: string;
+  /** 補足説明テキスト */
+  description?: string;
+  /** 入力要素 */
+  children: ReactNode;
+  /** エラーメッセージ */
+  error?: string | null;
+  /** 追加クラス名 */
+  className?: string;
+}
+
+/**
+ * 設定フォームフィールド — shadcn FormItem 相当
+ *
+ * label・入力・description・error を一貫した余白で配置する。
+ * gap-3 (12px) でラベルと入力の間を確保。
+ * フィールド同士の間隔は親側で制御（gap-10 等）。
+ */
+const SettingsField = memo<SettingsFieldProps>(
+  ({ label, htmlFor, description, children, error, className }) => {
+    return (
+      <div className={cn('flex flex-col gap-3', className)}>
+        <label htmlFor={htmlFor} className="text-sm text-muted-foreground">
+          {label}
+        </label>
+
+        {children}
+
+        {description && (
+          <p className="text-sm text-muted-foreground/70 leading-relaxed">
+            {description}
+          </p>
+        )}
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+      </div>
+    );
+  },
+);
+
+SettingsField.displayName = 'SettingsField';
+
+export { SettingsField };
+export type { SettingsFieldProps };

--- a/src/v2/components/settings/common/SettingsInfoBox.tsx
+++ b/src/v2/components/settings/common/SettingsInfoBox.tsx
@@ -13,7 +13,7 @@ const infoBoxVariants = cva('rounded-lg', {
   variants: {
     variant: {
       /** 一般的な情報・ヒント */
-      info: 'bg-primary/10 dark:bg-primary/20',
+      info: 'bg-primary/10',
       /** 注意事項 */
       warning: STATUS_COLOR.warning.bg,
       /** 成功・完了 */

--- a/src/v2/components/settings/common/SettingsInfoBox.tsx
+++ b/src/v2/components/settings/common/SettingsInfoBox.tsx
@@ -88,7 +88,7 @@ const SettingsInfoBox = memo<SettingsInfoBoxProps>(
             {title}
           </h4>
         )}
-        <div className={cn('text-[12px] leading-relaxed', `${textColor}/60`)}>
+        <div className={cn('text-[12px] leading-relaxed', textColor)}>
           {children}
         </div>
       </div>

--- a/src/v2/components/settings/common/SettingsInfoBox.tsx
+++ b/src/v2/components/settings/common/SettingsInfoBox.tsx
@@ -74,7 +74,7 @@ const SettingsInfoBox = memo<SettingsInfoBoxProps>(
         {title && (
           <h4
             className={cn(
-              'flex items-center text-[13px] font-medium',
+              'flex items-center text-sm font-medium',
               textColor,
               'mb-3',
             )}
@@ -88,7 +88,7 @@ const SettingsInfoBox = memo<SettingsInfoBoxProps>(
             {title}
           </h4>
         )}
-        <div className={cn('text-[12px] leading-relaxed', textColor)}>
+        <div className={cn('text-sm leading-relaxed', textColor)}>
           {children}
         </div>
       </div>

--- a/src/v2/components/settings/common/SettingsInfoBox.tsx
+++ b/src/v2/components/settings/common/SettingsInfoBox.tsx
@@ -4,20 +4,17 @@ import type { ReactNode } from 'react';
 import { memo } from 'react';
 
 import { cn } from '../../../../components/lib/utils';
-import { SPACING, STATUS_COLOR, TYPOGRAPHY } from '../../../constants/ui';
+import { STATUS_COLOR } from '../../../constants/ui';
 
 /**
- * InfoBoxのバリアント定義
+ * InfoBoxのバリアント定義 — 背景はほぼ透明、主張しない
  */
-const infoBoxVariants = cva('rounded-xl', {
+const infoBoxVariants = cva('rounded-2xl', {
   variants: {
     variant: {
-      /** 一般的な情報・ヒント — 極めて薄い背景で主張しすぎない */
-      info: 'bg-primary/5',
-      /** 注意事項 */
-      warning: 'bg-warning/5',
-      /** 成功・完了 */
-      success: 'bg-success/5',
+      info: 'bg-primary/[0.03]',
+      warning: 'bg-warning/[0.03]',
+      success: 'bg-success/[0.03]',
     },
   },
   defaultVariants: {
@@ -38,9 +35,6 @@ interface SettingsInfoBoxProps extends InfoBoxVariantProps {
   className?: string;
 }
 
-/**
- * バリアントに対応するアイコンを取得
- */
 const getVariantIcon = (variant: InfoBoxVariantProps['variant']) => {
   switch (variant) {
     case 'warning':
@@ -54,9 +48,6 @@ const getVariantIcon = (variant: InfoBoxVariantProps['variant']) => {
   }
 };
 
-/**
- * バリアントに対応するテキストカラーを取得
- */
 const getTextColorClass = (variant: InfoBoxVariantProps['variant']) => {
   switch (variant) {
     case 'warning':
@@ -71,22 +62,7 @@ const getTextColorClass = (variant: InfoBoxVariantProps['variant']) => {
 };
 
 /**
- * 設定画面用の情報ボックスコンポーネント
- *
- * ヒント、注意事項、成功メッセージなどを表示する。
- *
- * @example
- * <SettingsInfoBox title="インポート機能について">
- *   <ul>
- *     <li>• logStoreファイルを統合します</li>
- *     <li>• 重複データは除外されます</li>
- *   </ul>
- * </SettingsInfoBox>
- *
- * @example
- * <SettingsInfoBox variant="warning" title="注意">
- *   この操作は元に戻せません
- * </SettingsInfoBox>
+ * 情報ボックス — 極めて控えめな背景、広い余白
  */
 const SettingsInfoBox = memo<SettingsInfoBoxProps>(
   ({ title, variant = 'info', children, hideIcon, className }) => {
@@ -94,27 +70,25 @@ const SettingsInfoBox = memo<SettingsInfoBoxProps>(
     const textColor = getTextColorClass(variant);
 
     return (
-      <div
-        className={cn(
-          infoBoxVariants({ variant }),
-          SPACING.padding.sm,
-          className,
-        )}
-      >
+      <div className={cn(infoBoxVariants({ variant }), 'px-6 py-5', className)}>
         {title && (
           <h4
             className={cn(
-              'flex items-center',
-              TYPOGRAPHY.body.emphasis,
+              'flex items-center text-[13px] font-medium',
               textColor,
-              'mb-2',
+              'mb-3',
             )}
           >
-            {!hideIcon && <Icon className="h-4 w-4 mr-2" aria-hidden="true" />}
+            {!hideIcon && (
+              <Icon
+                className="h-3.5 w-3.5 mr-2.5 opacity-60"
+                aria-hidden="true"
+              />
+            )}
             {title}
           </h4>
         )}
-        <div className={cn(TYPOGRAPHY.body.small, `${textColor}/80`)}>
+        <div className={cn('text-[12px] leading-relaxed', `${textColor}/60`)}>
           {children}
         </div>
       </div>

--- a/src/v2/components/settings/common/SettingsInfoBox.tsx
+++ b/src/v2/components/settings/common/SettingsInfoBox.tsx
@@ -9,15 +9,15 @@ import { SPACING, STATUS_COLOR, TYPOGRAPHY } from '../../../constants/ui';
 /**
  * InfoBoxのバリアント定義
  */
-const infoBoxVariants = cva('rounded-lg', {
+const infoBoxVariants = cva('rounded-xl', {
   variants: {
     variant: {
-      /** 一般的な情報・ヒント */
-      info: 'bg-primary/10',
+      /** 一般的な情報・ヒント — 極めて薄い背景で主張しすぎない */
+      info: 'bg-primary/5',
       /** 注意事項 */
-      warning: STATUS_COLOR.warning.bg,
+      warning: 'bg-warning/5',
       /** 成功・完了 */
-      success: STATUS_COLOR.success.bg,
+      success: 'bg-success/5',
     },
   },
   defaultVariants: {
@@ -97,7 +97,7 @@ const SettingsInfoBox = memo<SettingsInfoBoxProps>(
       <div
         className={cn(
           infoBoxVariants({ variant }),
-          SPACING.padding.card,
+          SPACING.padding.sm,
           className,
         )}
       >

--- a/src/v2/components/settings/common/SettingsItem.tsx
+++ b/src/v2/components/settings/common/SettingsItem.tsx
@@ -34,13 +34,13 @@ const SettingsItem = memo<SettingsItemProps>(
       >
         <div className="flex-1 min-w-0 mr-12">
           <div
-            className="text-[13px] text-foreground/90"
+            className="text-[13px] text-foreground"
             id={`settings-item-${label.replaceAll(/\s+/g, '-').toLowerCase()}`}
           >
             {label}
           </div>
           {description && (
-            <div className="text-[12px] mt-1.5 text-muted-foreground/45 leading-relaxed">
+            <div className="text-[12px] mt-1.5 text-muted-foreground leading-relaxed">
               {description}
             </div>
           )}

--- a/src/v2/components/settings/common/SettingsItem.tsx
+++ b/src/v2/components/settings/common/SettingsItem.tsx
@@ -2,7 +2,6 @@ import type { ReactNode } from 'react';
 import { memo } from 'react';
 
 import { cn } from '../../../../components/lib/utils';
-import { TEXT_COLOR } from '../../../constants/ui';
 
 interface SettingsItemProps {
   /** 設定項目のラベル */
@@ -20,45 +19,29 @@ interface SettingsItemProps {
 /**
  * 設定項目コンポーネント
  *
- * ラベル + 説明 + 操作要素のレイアウトを提供。
- * トグルスイッチ、セレクトボックスなどの設定項目に使用。
- *
- * @example
- * <SettingsItem
- *   label="自動起動"
- *   description="システム起動時にアプリを自動的に起動します"
- * >
- *   <Switch checked={autoStart} onCheckedChange={setAutoStart} />
- * </SettingsItem>
- *
- * @example
- * <SettingsItem label="言語">
- *   <Select value={language} onValueChange={setLanguage}>
- *     <SelectItem value="ja">日本語</SelectItem>
- *     <SelectItem value="en">English</SelectItem>
- *   </Select>
- * </SettingsItem>
+ * Arc風：ラベルと操作要素を広い余白で配置。
+ * 各項目間の「呼吸」を最大化する。
  */
 const SettingsItem = memo<SettingsItemProps>(
   ({ label, description, children, disabled, className }) => {
     return (
       <div
         className={cn(
-          'flex items-center justify-between py-2',
-          disabled && 'opacity-40',
+          'flex items-center justify-between py-3',
+          disabled && 'opacity-35',
           className,
         )}
       >
-        {/* ラベルと説明 */}
-        <div className="flex-1 min-w-0 mr-6">
+        {/* ラベルと説明 — 広いマージンで操作要素と分離 */}
+        <div className="flex-1 min-w-0 mr-8">
           <div
-            className={cn('text-sm font-medium', TEXT_COLOR.primary)}
+            className="text-[13px] font-medium text-foreground"
             id={`settings-item-${label.replaceAll(/\s+/g, '-').toLowerCase()}`}
           >
             {label}
           </div>
           {description && (
-            <div className={cn('text-xs mt-0.5', TEXT_COLOR.secondary)}>
+            <div className="text-[12px] mt-1 text-muted-foreground/60 leading-relaxed">
               {description}
             </div>
           )}

--- a/src/v2/components/settings/common/SettingsItem.tsx
+++ b/src/v2/components/settings/common/SettingsItem.tsx
@@ -34,13 +34,13 @@ const SettingsItem = memo<SettingsItemProps>(
       >
         <div className="flex-1 min-w-0 mr-12">
           <div
-            className="text-[13px] text-foreground"
+            className="text-sm text-foreground"
             id={`settings-item-${label.replaceAll(/\s+/g, '-').toLowerCase()}`}
           >
             {label}
           </div>
           {description && (
-            <div className="text-[12px] mt-1.5 text-muted-foreground leading-relaxed">
+            <div className="text-sm mt-1.5 text-muted-foreground leading-relaxed">
               {description}
             </div>
           )}

--- a/src/v2/components/settings/common/SettingsItem.tsx
+++ b/src/v2/components/settings/common/SettingsItem.tsx
@@ -17,37 +17,35 @@ interface SettingsItemProps {
 }
 
 /**
- * 設定項目コンポーネント
+ * 設定項目 — Arc/Claude 風：各アイテムが広い余白の中に浮く
  *
- * Arc風：ラベルと操作要素を広い余白で配置。
- * 各項目間の「呼吸」を最大化する。
+ * ラベルは普通の weight、description はかなり薄い。
+ * 操作要素との間に十分なマージン。
  */
 const SettingsItem = memo<SettingsItemProps>(
   ({ label, description, children, disabled, className }) => {
     return (
       <div
         className={cn(
-          'flex items-center justify-between py-3',
-          disabled && 'opacity-35',
+          'flex items-center justify-between py-4',
+          disabled && 'opacity-30',
           className,
         )}
       >
-        {/* ラベルと説明 — 広いマージンで操作要素と分離 */}
-        <div className="flex-1 min-w-0 mr-8">
+        <div className="flex-1 min-w-0 mr-12">
           <div
-            className="text-[13px] font-medium text-foreground"
+            className="text-[13px] text-foreground/90"
             id={`settings-item-${label.replaceAll(/\s+/g, '-').toLowerCase()}`}
           >
             {label}
           </div>
           {description && (
-            <div className="text-[12px] mt-1 text-muted-foreground/60 leading-relaxed">
+            <div className="text-[12px] mt-1.5 text-muted-foreground/45 leading-relaxed">
               {description}
             </div>
           )}
         </div>
 
-        {/* 操作要素 */}
         <div className="flex-shrink-0">{children}</div>
       </div>
     );

--- a/src/v2/components/settings/common/SettingsItem.tsx
+++ b/src/v2/components/settings/common/SettingsItem.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import { memo } from 'react';
 
 import { cn } from '../../../../components/lib/utils';
-import { TEXT_COLOR, TYPOGRAPHY } from '../../../constants/ui';
+import { TEXT_COLOR } from '../../../constants/ui';
 
 interface SettingsItemProps {
   /** 設定項目のラベル */
@@ -44,21 +44,21 @@ const SettingsItem = memo<SettingsItemProps>(
     return (
       <div
         className={cn(
-          'flex items-center justify-between',
-          disabled && 'opacity-50',
+          'flex items-center justify-between py-2',
+          disabled && 'opacity-40',
           className,
         )}
       >
         {/* ラベルと説明 */}
-        <div className="flex-1 min-w-0 mr-4">
+        <div className="flex-1 min-w-0 mr-6">
           <div
-            className={cn(TYPOGRAPHY.body.emphasis, TEXT_COLOR.primary)}
+            className={cn('text-sm font-medium', TEXT_COLOR.primary)}
             id={`settings-item-${label.replaceAll(/\s+/g, '-').toLowerCase()}`}
           >
             {label}
           </div>
           {description && (
-            <div className={cn(TYPOGRAPHY.body.small, TEXT_COLOR.secondary)}>
+            <div className={cn('text-xs mt-0.5', TEXT_COLOR.secondary)}>
               {description}
             </div>
           )}

--- a/src/v2/components/settings/common/SettingsPathInput.tsx
+++ b/src/v2/components/settings/common/SettingsPathInput.tsx
@@ -63,10 +63,7 @@ const SettingsPathInput = memo<SettingsPathInputProps>(
     return (
       <div className={cn('space-y-4', className)}>
         {/* ラベル */}
-        <label
-          htmlFor={inputId}
-          className="text-[12px] text-muted-foreground/45"
-        >
+        <label htmlFor={inputId} className="text-[12px] text-muted-foreground">
           {label}
         </label>
 
@@ -111,7 +108,7 @@ const SettingsPathInput = memo<SettingsPathInputProps>(
 
         {/* エラーメッセージ */}
         {error && (
-          <div className="flex items-center text-[12px] text-destructive/70">
+          <div className="flex items-center text-[12px] text-destructive">
             <AlertCircle className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
             <span>{error}</span>
           </div>

--- a/src/v2/components/settings/common/SettingsPathInput.tsx
+++ b/src/v2/components/settings/common/SettingsPathInput.tsx
@@ -61,7 +61,7 @@ const SettingsPathInput = memo<SettingsPathInputProps>(
     const inputId = `path-input-${label.replaceAll(/\s+/g, '-').toLowerCase()}`;
 
     return (
-      <div className={cn('space-y-4', className)}>
+      <div className={cn('space-y-6', className)}>
         {/* ラベル */}
         <label htmlFor={inputId} className="text-sm text-muted-foreground">
           {label}

--- a/src/v2/components/settings/common/SettingsPathInput.tsx
+++ b/src/v2/components/settings/common/SettingsPathInput.tsx
@@ -38,20 +38,7 @@ interface SettingsPathInputProps {
 /**
  * 設定画面用のパス入力コンポーネント
  *
- * Input + 参照/保存ボタン + エラー表示を提供。
- * 写真ディレクトリやログファイルのパス設定に使用。
- *
- * @example
- * <SettingsPathInput
- *   label="写真ディレクトリ"
- *   value={photoPath}
- *   onChange={setPhotoPath}
- *   onBrowse={handleBrowse}
- *   onSave={handleSave}
- *   isManuallyChanged={hasChanges}
- *   error={validationError}
- *   placeholder="/path/to/photos"
- * />
+ * Arc風：ラベルは小さく控えめ、入力欄は広い余白の中に浮く。
  */
 const SettingsPathInput = memo<SettingsPathInputProps>(
   ({
@@ -76,17 +63,17 @@ const SettingsPathInput = memo<SettingsPathInputProps>(
     const inputId = `path-input-${label.replaceAll(/\s+/g, '-').toLowerCase()}`;
 
     return (
-      <div className={cn('space-y-2.5', className)}>
-        {/* ラベル */}
+      <div className={cn('space-y-3', className)}>
+        {/* ラベル — 極めて控えめ */}
         <label
           htmlFor={inputId}
-          className="text-xs font-medium text-muted-foreground/70"
+          className="text-[12px] font-medium text-muted-foreground/60"
         >
           {label}
         </label>
 
-        {/* 入力欄とボタン */}
-        <div className="flex gap-2.5">
+        {/* 入力欄とボタン — ゆったりした gap */}
+        <div className="flex gap-3">
           <Input
             id={inputId}
             type="text"
@@ -125,8 +112,8 @@ const SettingsPathInput = memo<SettingsPathInputProps>(
 
         {/* エラーメッセージ */}
         {error && (
-          <div className="flex items-center text-sm text-destructive">
-            <AlertCircle className="h-4 w-4 mr-1 flex-shrink-0" />
+          <div className="flex items-center text-[12px] text-destructive/80">
+            <AlertCircle className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
             <span>{error}</span>
           </div>
         )}

--- a/src/v2/components/settings/common/SettingsPathInput.tsx
+++ b/src/v2/components/settings/common/SettingsPathInput.tsx
@@ -36,9 +36,7 @@ interface SettingsPathInputProps {
 }
 
 /**
- * 設定画面用のパス入力コンポーネント
- *
- * Arc風：ラベルは小さく控えめ、入力欄は広い余白の中に浮く。
+ * パス入力 — ラベルと入力欄の間に十分な余白
  */
 const SettingsPathInput = memo<SettingsPathInputProps>(
   ({
@@ -63,16 +61,16 @@ const SettingsPathInput = memo<SettingsPathInputProps>(
     const inputId = `path-input-${label.replaceAll(/\s+/g, '-').toLowerCase()}`;
 
     return (
-      <div className={cn('space-y-3', className)}>
-        {/* ラベル — 極めて控えめ */}
+      <div className={cn('space-y-4', className)}>
+        {/* ラベル */}
         <label
           htmlFor={inputId}
-          className="text-[12px] font-medium text-muted-foreground/60"
+          className="text-[12px] text-muted-foreground/45"
         >
           {label}
         </label>
 
-        {/* 入力欄とボタン — ゆったりした gap */}
+        {/* 入力欄とボタン */}
         <div className="flex gap-3">
           <Input
             id={inputId}
@@ -100,10 +98,11 @@ const SettingsPathInput = memo<SettingsPathInputProps>(
             <Button
               type="button"
               aria-label={browseLabel ?? `参照-${label}`}
-              variant="secondary"
+              variant="ghost"
               size="sm"
               onClick={onBrowse}
               disabled={disabled ?? readOnly}
+              className="text-muted-foreground/50 hover:text-foreground"
             >
               <FolderOpen className="h-4 w-4" />
             </Button>
@@ -112,7 +111,7 @@ const SettingsPathInput = memo<SettingsPathInputProps>(
 
         {/* エラーメッセージ */}
         {error && (
-          <div className="flex items-center text-[12px] text-destructive/80">
+          <div className="flex items-center text-[12px] text-destructive/70">
             <AlertCircle className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
             <span>{error}</span>
           </div>

--- a/src/v2/components/settings/common/SettingsPathInput.tsx
+++ b/src/v2/components/settings/common/SettingsPathInput.tsx
@@ -1,10 +1,10 @@
-import { AlertCircle, FolderOpen, Save } from 'lucide-react';
+import { FolderOpen, Save } from 'lucide-react';
 import type { ChangeEvent } from 'react';
 import { memo } from 'react';
 
-import { cn } from '../../../../components/lib/utils';
 import { Button } from '../../../../components/ui/button';
 import { Input } from '../../../../components/ui/input';
+import { SettingsField } from './SettingsField';
 
 interface SettingsPathInputProps {
   /** ラベル */
@@ -36,7 +36,7 @@ interface SettingsPathInputProps {
 }
 
 /**
- * パス入力 — ラベルと入力欄の間に十分な余白
+ * パス入力 — SettingsField を使って label→input の余白を確実に確保
  */
 const SettingsPathInput = memo<SettingsPathInputProps>(
   ({
@@ -61,13 +61,12 @@ const SettingsPathInput = memo<SettingsPathInputProps>(
     const inputId = `path-input-${label.replaceAll(/\s+/g, '-').toLowerCase()}`;
 
     return (
-      <div className={cn('space-y-6', className)}>
-        {/* ラベル */}
-        <label htmlFor={inputId} className="text-sm text-muted-foreground">
-          {label}
-        </label>
-
-        {/* 入力欄とボタン */}
+      <SettingsField
+        label={label}
+        htmlFor={inputId}
+        error={error}
+        className={className}
+      >
         <div className="flex gap-3">
           <Input
             id={inputId}
@@ -105,15 +104,7 @@ const SettingsPathInput = memo<SettingsPathInputProps>(
             </Button>
           )}
         </div>
-
-        {/* エラーメッセージ */}
-        {error && (
-          <div className="flex items-center text-sm text-destructive">
-            <AlertCircle className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
-            <span>{error}</span>
-          </div>
-        )}
-      </div>
+      </SettingsField>
     );
   },
 );

--- a/src/v2/components/settings/common/SettingsPathInput.tsx
+++ b/src/v2/components/settings/common/SettingsPathInput.tsx
@@ -63,7 +63,7 @@ const SettingsPathInput = memo<SettingsPathInputProps>(
     return (
       <div className={cn('space-y-4', className)}>
         {/* ラベル */}
-        <label htmlFor={inputId} className="text-[12px] text-muted-foreground">
+        <label htmlFor={inputId} className="text-sm text-muted-foreground">
           {label}
         </label>
 
@@ -108,7 +108,7 @@ const SettingsPathInput = memo<SettingsPathInputProps>(
 
         {/* エラーメッセージ */}
         {error && (
-          <div className="flex items-center text-[12px] text-destructive">
+          <div className="flex items-center text-sm text-destructive">
             <AlertCircle className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
             <span>{error}</span>
           </div>

--- a/src/v2/components/settings/common/SettingsPathInput.tsx
+++ b/src/v2/components/settings/common/SettingsPathInput.tsx
@@ -5,7 +5,6 @@ import { memo } from 'react';
 import { cn } from '../../../../components/lib/utils';
 import { Button } from '../../../../components/ui/button';
 import { Input } from '../../../../components/ui/input';
-import { SPACING, TEXT_COLOR, TYPOGRAPHY } from '../../../constants/ui';
 
 interface SettingsPathInputProps {
   /** ラベル */
@@ -77,17 +76,17 @@ const SettingsPathInput = memo<SettingsPathInputProps>(
     const inputId = `path-input-${label.replaceAll(/\s+/g, '-').toLowerCase()}`;
 
     return (
-      <div className={cn(SPACING.stack.default, className)}>
+      <div className={cn('space-y-2.5', className)}>
         {/* ラベル */}
         <label
           htmlFor={inputId}
-          className={cn(TYPOGRAPHY.body.emphasis, TEXT_COLOR.secondary)}
+          className="text-xs font-medium text-muted-foreground/70"
         >
           {label}
         </label>
 
         {/* 入力欄とボタン */}
-        <div className="flex gap-2">
+        <div className="flex gap-2.5">
           <Input
             id={inputId}
             type="text"

--- a/src/v2/components/settings/common/SettingsSection.tsx
+++ b/src/v2/components/settings/common/SettingsSection.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react';
 import { memo } from 'react';
 
 import { cn } from '../../../../components/lib/utils';
-import { SPACING, TEXT_COLOR, TYPOGRAPHY } from '../../../constants/ui';
+import { SPACING, TEXT_COLOR } from '../../../constants/ui';
 
 interface SettingsSectionProps {
   /** セクションアイコン */
@@ -43,30 +43,33 @@ interface SettingsSectionProps {
 const SettingsSection = memo<SettingsSectionProps>(
   ({ icon: Icon, title, description, children, className }) => {
     return (
-      <section className={cn(SPACING.stack.loose, className)}>
-        {/* ヘッダー */}
-        <div className={SPACING.stack.tight}>
+      <section className={cn('mb-10', className)}>
+        {/* ヘッダー — 余白を広めに取ってセクション感を出す */}
+        <div className="mb-6">
           <h3
             className={cn(
               'flex items-center',
-              TYPOGRAPHY.heading.secondary,
-              TEXT_COLOR.primary,
+              'text-[13px] font-semibold uppercase tracking-wider',
+              'text-muted-foreground/50',
             )}
           >
             {Icon && (
-              <Icon className="h-5 w-5 mr-2 text-primary" aria-hidden="true" />
+              <Icon
+                className="h-3.5 w-3.5 mr-2 opacity-50"
+                aria-hidden="true"
+              />
             )}
             {title}
           </h3>
           {description && (
-            <p className={cn(TYPOGRAPHY.body.default, TEXT_COLOR.secondary)}>
+            <p className={cn('mt-1.5 text-sm', TEXT_COLOR.secondary)}>
               {description}
             </p>
           )}
         </div>
 
-        {/* コンテンツ */}
-        <div className={SPACING.stack.relaxed}>{children}</div>
+        {/* コンテンツ — ゆったりスペース */}
+        <div className={SPACING.stack.loose}>{children}</div>
       </section>
     );
   },

--- a/src/v2/components/settings/common/SettingsSection.tsx
+++ b/src/v2/components/settings/common/SettingsSection.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from 'react';
 import { memo } from 'react';
 
 import { cn } from '../../../../components/lib/utils';
-import { SPACING, TEXT_COLOR } from '../../../constants/ui';
 
 interface SettingsSectionProps {
   /** セクションアイコン */
@@ -21,55 +20,30 @@ interface SettingsSectionProps {
 /**
  * 設定セクションコンテナ
  *
- * アイコン付きヘッダーと一貫したスペーシングを提供。
- * 設定画面内の各セクションを統一的にレイアウトする。
- *
- * @example
- * <SettingsSection icon={Palette} title="テーマ設定">
- *   <ThemeOptions />
- * </SettingsSection>
- *
- * @example
- * <SettingsSection
- *   icon={Settings}
- *   title="システム設定"
- *   description="アプリの動作に関する設定"
- * >
- *   <SettingsItem label="自動起動">
- *     <Switch />
- *   </SettingsItem>
- * </SettingsSection>
+ * Arc風の広大な余白を持つセクションレイアウト。
+ * タイトルは控えめな overline スタイル、コンテンツは大きな余白で呼吸させる。
  */
 const SettingsSection = memo<SettingsSectionProps>(
   ({ icon: Icon, title, description, children, className }) => {
     return (
-      <section className={cn('mb-10', className)}>
-        {/* ヘッダー — 余白を広めに取ってセクション感を出す */}
-        <div className="mb-6">
-          <h3
-            className={cn(
-              'flex items-center',
-              'text-[13px] font-semibold uppercase tracking-wider',
-              'text-muted-foreground/50',
-            )}
-          >
+      <section className={cn('mb-14', className)}>
+        {/* セクションヘッダー — 控えめだが明確 */}
+        <div className="mb-8">
+          <h3 className="flex items-center text-[11px] font-semibold uppercase tracking-[0.1em] text-muted-foreground/40">
             {Icon && (
-              <Icon
-                className="h-3.5 w-3.5 mr-2 opacity-50"
-                aria-hidden="true"
-              />
+              <Icon className="h-3 w-3 mr-2 opacity-40" aria-hidden="true" />
             )}
             {title}
           </h3>
           {description && (
-            <p className={cn('mt-1.5 text-sm', TEXT_COLOR.secondary)}>
+            <p className="mt-2 text-[13px] text-muted-foreground/60 leading-relaxed">
               {description}
             </p>
           )}
         </div>
 
-        {/* コンテンツ — ゆったりスペース */}
-        <div className={SPACING.stack.loose}>{children}</div>
+        {/* コンテンツ — 各アイテム間を大きく空ける */}
+        <div className="space-y-6">{children}</div>
       </section>
     );
   },

--- a/src/v2/components/settings/common/SettingsSection.tsx
+++ b/src/v2/components/settings/common/SettingsSection.tsx
@@ -29,12 +29,12 @@ const SettingsSection = memo<SettingsSectionProps>(
       <section className={cn('mb-16', className)}>
         {/* セクションタイトル — 極限まで控えめ */}
         <div className="mb-10">
-          <h3 className="flex items-center text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground/35">
+          <h3 className="flex items-center text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground/70">
             {Icon && <Icon className="h-3 w-3 mr-2" aria-hidden="true" />}
             {title}
           </h3>
           {description && (
-            <p className="mt-3 text-[13px] text-muted-foreground/50 leading-relaxed max-w-md">
+            <p className="mt-3 text-[13px] text-muted-foreground leading-relaxed max-w-md">
               {description}
             </p>
           )}

--- a/src/v2/components/settings/common/SettingsSection.tsx
+++ b/src/v2/components/settings/common/SettingsSection.tsx
@@ -18,32 +18,30 @@ interface SettingsSectionProps {
 }
 
 /**
- * 設定セクションコンテナ
+ * 設定セクションコンテナ — Arc/Claude風の圧倒的余白
  *
- * Arc風の広大な余白を持つセクションレイアウト。
- * タイトルは控えめな overline スタイル、コンテンツは大きな余白で呼吸させる。
+ * セクション間は56px以上。タイトルは極めて控えめな overline。
+ * コンテンツは広大な余白の中に浮かぶ。
  */
 const SettingsSection = memo<SettingsSectionProps>(
   ({ icon: Icon, title, description, children, className }) => {
     return (
-      <section className={cn('mb-14', className)}>
-        {/* セクションヘッダー — 控えめだが明確 */}
-        <div className="mb-8">
-          <h3 className="flex items-center text-[11px] font-semibold uppercase tracking-[0.1em] text-muted-foreground/40">
-            {Icon && (
-              <Icon className="h-3 w-3 mr-2 opacity-40" aria-hidden="true" />
-            )}
+      <section className={cn('mb-16', className)}>
+        {/* セクションタイトル — 極限まで控えめ */}
+        <div className="mb-10">
+          <h3 className="flex items-center text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground/35">
+            {Icon && <Icon className="h-3 w-3 mr-2" aria-hidden="true" />}
             {title}
           </h3>
           {description && (
-            <p className="mt-2 text-[13px] text-muted-foreground/60 leading-relaxed">
+            <p className="mt-3 text-[13px] text-muted-foreground/50 leading-relaxed max-w-md">
               {description}
             </p>
           )}
         </div>
 
-        {/* コンテンツ — 各アイテム間を大きく空ける */}
-        <div className="space-y-6">{children}</div>
+        {/* コンテンツ — 要素間を大きく空ける */}
+        <div className="space-y-8">{children}</div>
       </section>
     );
   },

--- a/src/v2/components/settings/common/SettingsSection.tsx
+++ b/src/v2/components/settings/common/SettingsSection.tsx
@@ -29,12 +29,12 @@ const SettingsSection = memo<SettingsSectionProps>(
       <section className={cn('mb-16', className)}>
         {/* セクションタイトル — 極限まで控えめ */}
         <div className="mb-10">
-          <h3 className="flex items-center text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground/70">
+          <h3 className="flex items-center text-xs font-medium uppercase tracking-widest text-muted-foreground/70">
             {Icon && <Icon className="h-3 w-3 mr-2" aria-hidden="true" />}
             {title}
           </h3>
           {description && (
-            <p className="mt-3 text-[13px] text-muted-foreground leading-relaxed max-w-md">
+            <p className="mt-3 text-sm text-muted-foreground leading-relaxed max-w-md">
               {description}
             </p>
           )}

--- a/src/v2/components/settings/common/index.ts
+++ b/src/v2/components/settings/common/index.ts
@@ -17,3 +17,6 @@ export { SettingsPathInput } from './SettingsPathInput';
 export type { SettingsSectionProps } from './SettingsSection';
 // セクションコンテナ
 export { SettingsSection } from './SettingsSection';
+export type { SettingsFieldProps } from './SettingsField';
+// フォームフィールド（label + input + error の余白統一）
+export { SettingsField } from './SettingsField';

--- a/src/v2/constants/__tests__/layoutConstants.test.ts
+++ b/src/v2/constants/__tests__/layoutConstants.test.ts
@@ -47,9 +47,9 @@ describe('LAYOUT_CONSTANTS', () => {
   it('期待される値が設定されている', () => {
     // Tailwind CSS クラスとの対応を確認
     expect(LAYOUT_CONSTANTS.TARGET_ROW_HEIGHT).toBe(200);
-    expect(LAYOUT_CONSTANTS.GAP).toBe(8); // 8pxベースグリッドに準拠
-    expect(LAYOUT_CONSTANTS.HEADER_HEIGHT).toBe(96); // h-24 = 96px
-    expect(LAYOUT_CONSTANTS.SPACING).toBe(8); // space-y-2 = 8px
+    expect(LAYOUT_CONSTANTS.GAP).toBe(6); // gap-1.5 = 6px
+    expect(LAYOUT_CONSTANTS.HEADER_HEIGHT).toBe(80); // py-4 + 内部コンテンツ
+    expect(LAYOUT_CONSTANTS.SPACING).toBe(0); // ヘッダーとグリッド間の余白なし
     expect(LAYOUT_CONSTANTS.MAX_LAST_ROW_SCALE).toBe(1.5);
   });
 

--- a/src/v2/constants/layoutConstants.ts
+++ b/src/v2/constants/layoutConstants.ts
@@ -16,14 +16,14 @@ export const LAYOUT_CONSTANTS: LayoutConstants = {
   /** 写真グリッドの目標行高さ (px) */
   TARGET_ROW_HEIGHT: 200,
 
-  /** 写真間のギャップ (px) - 8pxベースグリッドに準拠 */
-  GAP: 8,
+  /** 写真間のギャップ (px) - Tailwind gap-1.5 に対応 */
+  GAP: 6,
 
-  /** LocationGroupHeader の高さ (px) - Tailwind の h-24 に対応 */
-  HEADER_HEIGHT: 96,
+  /** LocationGroupHeader の高さ (px) - py-4 + 内部コンテンツの近似値 */
+  HEADER_HEIGHT: 80,
 
-  /** ヘッダーとグリッド間のスペース (px) - Tailwind の space-y-2 に対応 */
-  SPACING: 8,
+  /** ヘッダーとグリッド間のスペース (px) - ヘッダーとグリッド間の余白 */
+  SPACING: 0,
 
   /** 最後の行の最大スケール倍率 */
   MAX_LAST_ROW_SCALE: 1.5,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -80,6 +80,7 @@ module.exports = {
       },
       fontFamily: {
         sans: [
+          '"Inter"',
           '"Noto Sans CJK JP"',
           '"Noto Sans JP"',
           '"-apple-system"',
@@ -128,9 +129,19 @@ module.exports = {
         '3xl': '64px',
       },
       boxShadow: {
-        glass: '0 4px 16px rgba(31, 38, 135, 0.15)',
-        'glass-inset': 'inset 0 1px 0 rgba(255, 255, 255, 0.05)',
-        'glass-hover': '0 6px 24px rgba(31, 38, 135, 0.25)',
+        /* Neutral soft shadows — Apple-inspired */
+        glass: '0 2px 12px rgba(0, 0, 0, 0.08)',
+        'glass-inset': 'inset 0 1px 0 rgba(255, 255, 255, 0.04)',
+        'glass-hover': '0 4px 16px rgba(0, 0, 0, 0.1)',
+        /* Elevated surface — dialogs, popovers */
+        elevated:
+          '0 8px 32px rgba(0, 0, 0, 0.08), 0 1px 4px rgba(0, 0, 0, 0.04)',
+        /* Subtle — cards, inputs on focus */
+        subtle: '0 1px 3px rgba(0, 0, 0, 0.04)',
+      },
+      transitionTimingFunction: {
+        /* Spring-like easing for delightful interactions */
+        spring: 'cubic-bezier(0.22, 1, 0.36, 1)',
       },
     },
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -129,19 +129,26 @@ module.exports = {
         '3xl': '64px',
       },
       boxShadow: {
-        /* Neutral soft shadows — Apple-inspired */
-        glass: '0 2px 12px rgba(0, 0, 0, 0.08)',
+        /* Neutral soft shadows — Apple/Arc-inspired layered depth */
+        glass: '0 2px 12px rgba(0, 0, 0, 0.06)',
         'glass-inset': 'inset 0 1px 0 rgba(255, 255, 255, 0.04)',
-        'glass-hover': '0 4px 16px rgba(0, 0, 0, 0.1)',
-        /* Elevated surface — dialogs, popovers */
+        'glass-hover': '0 8px 24px rgba(0, 0, 0, 0.1)',
+        /* Elevated surface — dialogs, popovers, floating cards */
         elevated:
-          '0 8px 32px rgba(0, 0, 0, 0.08), 0 1px 4px rgba(0, 0, 0, 0.04)',
-        /* Subtle — cards, inputs on focus */
-        subtle: '0 1px 3px rgba(0, 0, 0, 0.04)',
+          '0 8px 40px rgba(0, 0, 0, 0.08), 0 2px 6px rgba(0, 0, 0, 0.03)',
+        /* Subtle — resting cards */
+        subtle: '0 1px 4px rgba(0, 0, 0, 0.03)',
+        /* Float — hovered cards, interactive surfaces */
+        float: '0 8px 30px rgba(0, 0, 0, 0.07), 0 2px 6px rgba(0, 0, 0, 0.03)',
+        /* Glow — primary action hover */
+        glow: '0 4px 20px hsl(32 92% 56% / 0.2)',
       },
       transitionTimingFunction: {
         /* Spring-like easing for delightful interactions */
         spring: 'cubic-bezier(0.22, 1, 0.36, 1)',
+      },
+      transitionDuration: {
+        250: '250ms',
       },
     },
   },


### PR DESCRIPTION
## Summary

- **hover:scale-105 を全削除** — ボタン・ダイアログ等の過剰なスケール変換を背景色の変化に置き換え
- **Glass morphism を大幅簡素化** — LocationGroupHeader の3層オーバーレイを1層に、Input/Button の不要な backdrop-blur を削除
- **直接色指定をセマンティックトークンに統一** — `bg-gray-*`, `text-gray-*`, `bg-[#hex]` 等を `bg-muted`, `text-foreground` 等に（17ファイル）

### 変更の詳細

| カテゴリ | Before | After |
|---|---|---|
| ホバー | `hover:scale-105` | 背景色の変化のみ |
| 影 | `rgba(31, 38, 135, 0.15)` 紫がかり | `rgba(0, 0, 0, 0.08)` ニュートラル |
| ダーク彩度 | `hue 220 / sat 27%` | `hue 220 / sat 14-18%` |
| Glass層 | 3層オーバーレイ + blur 26px | 1層 + blur 24px |
| radius | 12px (`0.75rem`) | 10px (`0.625rem`) |
| トランジション | `transition-all duration-300` | `transition-colors duration-150` |
| フォント | Noto Sans のみ | Inter + Noto Sans |

**17ファイル変更、175行追加 / 276行削除（差し引き -101行）**

## Test plan

- [x] `pnpm lint:fix` → pass
- [x] `pnpm lint` → エラーなし（既存 warning のみ）
- [x] `pnpm test` → 91ファイル / 797テスト all pass
- [ ] ライトモードでの表示確認
- [ ] ダークモードでの表示確認
- [ ] ボタン・ダイアログ等のホバー状態の確認
- [ ] LocationGroupHeader のサムネイル表示確認

https://claude.ai/code/session_01Pb2RhwMaXkMK6F9vuYpB8j

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More consistent settings form fields and a reusable field wrapper for clearer labels, descriptions, and errors.

* **Style**
  * Refreshed color tokens and shadows; removed many glass/blur overlays for a cleaner look.
  * Unified button/input/dialog/photo visuals, rounded corners, and hover/active interactions with smoother springy transitions.
  * Adjusted spacing/layout (headers, photo grid, sidebars) and scrollbar appearance for tighter, more consistent spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->