### PR TITLE
test(e2e): 設定モーダルのパス設定画面をスクショ撮影

### DIFF
--- a/playwright/screenshot.spec.ts
+++ b/playwright/screenshot.spec.ts
@@ -142,6 +142,32 @@ const screenshot = async (page: Page, title: string, suffix: string) => {
   }
 };
 
+/**
+ * 設定モーダルを開いてパス設定タブのスクショを撮り、モーダルを閉じる。
+ * AppHeader の設定ボタン (aria-label="設定") をクリックして、
+ * モーダル初期表示タブ (パス設定) を撮影する。
+ */
+const captureSettingsPaths = async (page: Page, title: string) => {
+  try {
+    const settingsButton = await page.waitForSelector('[aria-label="設定"]', {
+      timeout: 5000,
+    });
+    await settingsButton.click();
+    // モーダルが完全にレンダリングされるのを待つ (パス設定セクションの要素を検出)
+    await page.waitForSelector('[aria-label="input-写真ディレクトリ"]', {
+      timeout: 5000,
+    });
+    await page.waitForTimeout(500);
+    await screenshot(page, title, 'settings-paths');
+    // モーダルを閉じる
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(500);
+  } catch (error) {
+    console.error('Failed to capture settings paths screenshot:', error);
+    throw error;
+  }
+};
+
 const TIMEOUT = 60000; // Increased timeout to 60 seconds
 
 test.setTimeout(TIMEOUT);
@@ -235,6 +261,7 @@ test('各画面でスクショ', async () => {
     if (hasMainContent) {
       console.log('Main screen already loaded, skipping setup');
       await screenshot(page, title, 'main-already-loaded');
+      await captureSettingsPaths(page, title);
       // Exit app.
       await electronApp.close();
       return;
@@ -324,6 +351,9 @@ test('各画面でスクショ', async () => {
     // 最後の状態をスクショ
     await page.waitForTimeout(500);
     await screenshot(page, title, 'finalized');
+
+    // 設定モーダルを開いてパス設定画面をスクショ
+    await captureSettingsPaths(page, title);
   } catch (error) {
     console.log('Failed to wait for main content, checking page status...');
 
@@ -359,6 +389,7 @@ test('各画面でスクショ', async () => {
     'setup',
     'logs-loaded',
     'finalized',
+    'settings-paths',
   ];
 
   for (const name of requiredScreenshots) {

--- a/playwright/screenshot.spec.ts
+++ b/playwright/screenshot.spec.ts
@@ -144,28 +144,29 @@ const screenshot = async (page: Page, title: string, suffix: string) => {
 
 /**
  * 設定モーダルを開いてパス設定タブのスクショを撮り、モーダルを閉じる。
- * AppHeader の設定ボタン (aria-label="設定") をクリックして、
- * モーダル初期表示タブ (パス設定) を撮影する。
+ * JA ロケール前提 (AppHeader の aria-label が t('common.settings') で "設定")。
+ * モーダル内スコープ ([role="dialog"]) でセレクタを限定することで、
+ * セットアップ画面の同名セレクタとの誤マッチを防ぐ。
  */
 const captureSettingsPaths = async (page: Page, title: string) => {
-  try {
-    const settingsButton = await page.waitForSelector('[aria-label="設定"]', {
-      timeout: 5000,
-    });
-    await settingsButton.click();
-    // モーダルが完全にレンダリングされるのを待つ (パス設定セクションの要素を検出)
-    await page.waitForSelector('[aria-label="input-写真ディレクトリ"]', {
-      timeout: 5000,
-    });
-    await page.waitForTimeout(500);
-    await screenshot(page, title, 'settings-paths');
-    // モーダルを閉じる
-    await page.keyboard.press('Escape');
-    await page.waitForTimeout(500);
-  } catch (error) {
-    console.error('Failed to capture settings paths screenshot:', error);
-    throw error;
-  }
+  const settingsButton = await page.waitForSelector('[aria-label="設定"]', {
+    timeout: 5000,
+  });
+  await settingsButton.click();
+  // Radix Dialog のフェードイン完了とパス設定要素の表示を待つ
+  const dialogPhotoInput =
+    '[role="dialog"] [aria-label="input-写真ディレクトリ"]';
+  await page.waitForSelector(dialogPhotoInput, {
+    timeout: 5000,
+    state: 'visible',
+  });
+  await screenshot(page, title, 'settings-paths');
+  // 後続の操作に副作用を残さないためモーダルを確実に閉じる
+  await page.keyboard.press('Escape');
+  await page.waitForSelector(dialogPhotoInput, {
+    state: 'hidden',
+    timeout: 5000,
+  });
 };
 
 const TIMEOUT = 60000; // Increased timeout to 60 seconds

--- a/src/v2/components/AppHeader.tsx
+++ b/src/v2/components/AppHeader.tsx
@@ -150,6 +150,8 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
                 size="sm"
                 onClick={onOpenSettings}
                 className="h-7 w-7 p-0"
+                aria-label={t('common.settings')}
+                title={t('common.settings')}
               >
                 <Settings className={ICON_SIZE.sm.class} />
               </Button>


### PR DESCRIPTION
## Summary

- Playwright e2e スクショテストに、設定モーダルのパス設定画面の撮影を追加 (`VRChatAlbums-settings-paths.png`)
- AppHeader の設定ボタンに `aria-label` / `title` を付与（a11y 改善 + テスト用セレクタ確保）
- 設定モーダルを開閉するヘルパー `captureSettingsPaths` を追加し、`main-already-loaded` 経路と通常フロー両方で撮影

## 実装のポイント

- セレクタは `[role="dialog"]` でスコープ限定し、セットアップ画面の同名 `aria-label` との誤マッチを回避
- `waitForTimeout` を使わず `waitForSelector({ state: 'visible' / 'hidden' })` で状態ベースに待機（flakiness 対策）
- JA ロケール前提を JSDoc に明記（既存 E2E の JA セレクタ群と整合）

## Test plan

- [ ] `pnpm lint` が通る
- [ ] `pnpm test` が通る (91 files / 797 passed 確認済み)
- [ ] Playwright e2e 実行後、`playwright/previews/VRChatAlbums-settings-paths.png` にパス設定画面のスクショが生成される
- [ ] スクショにパス入力フィールド（写真ディレクトリ / VRChatログファイルディレクトリ）が映っている

https://claude.ai/code/session_01Mg6DwAjkHDqfhPeXvHHXqo