### PR TITLE
refactor(electron): Effect TS の重複ボイラープレートを SSOT 化

### DIFF
--- a/.changeset/refactor-effect-mapping-helpers.md
+++ b/.changeset/refactor-effect-mapping-helpers.md
@@ -1,0 +1,17 @@
+---
+'vrchat-albums': patch
+---
+
+refactor(electron): Effect TS の重複ボイラープレートを SSOT 化
+
+各 tRPC コントローラーで重複していた `Effect.mapError(e => UserFacingError.withStructuredInfo({...}))`
+パターンを `electron/lib/errorMapping.ts` の `toUserFacing` / `mapByTag` /
+プリセットマッパー (`mapToFileOperationError` / `mapToOpenPathError` / `mapToUnknownError`)
+に集約。Electron 環境検出パターンも `withElectronApp(fallback, fn)` に統一。
+
+ユーザー向け挙動の変更はなし。エラーメッセージの内容と表示タイミングは旧コードと等価。
+
+- 新規: `electron/lib/errorMapping.ts`, `errorMapping.test.ts`
+- 追加: `electron/lib/electronModules.ts` に `withElectronApp` ヘルパー
+- 削除: `electron/lib/dbHelper.ts` の未使用コメントアウト 150 行と未使用エラー型
+- ast-grep ルール 3 本追加/更新で将来の再発を防止

--- a/electron/api.ts
+++ b/electron/api.ts
@@ -3,6 +3,7 @@ import z from 'zod';
 
 import { initializeMainSentry } from './index';
 import { runEffect, runEffectExit } from './lib/effectTRPC';
+import { mapToFileOperationError } from './lib/errorMapping';
 import { ERROR_CATEGORIES, ERROR_CODES, UserFacingError } from './lib/errors';
 import { logger } from './lib/logger';
 import { backgroundSettingsRouter } from './module/backgroundSettings/controller/backgroundSettingsController';
@@ -180,49 +181,25 @@ export const router = trpcRouter({
     }),
   openPathOnExplorer: procedure.input(z.string()).mutation(async (ctx) => {
     await runEffect(
-      service.openPathOnExplorer(ctx.input).pipe(
-        Effect.mapError((e) =>
-          UserFacingError.withStructuredInfo({
-            code: ERROR_CODES.UNKNOWN,
-            category: ERROR_CATEGORIES.UNKNOWN_ERROR,
-            message: String(e),
-            userMessage: 'ファイル操作中にエラーが発生しました。',
-            cause: e instanceof Error ? e : new Error(String(e)),
-          }),
-        ),
-      ),
+      service
+        .openPathOnExplorer(ctx.input)
+        .pipe(Effect.mapError(mapToFileOperationError)),
     );
     return true;
   }),
   openElectronLogOnExplorer: procedure.mutation(async () => {
     await runEffect(
-      service.openElectronLogOnExplorer().pipe(
-        Effect.mapError((e) =>
-          UserFacingError.withStructuredInfo({
-            code: ERROR_CODES.UNKNOWN,
-            category: ERROR_CATEGORIES.UNKNOWN_ERROR,
-            message: String(e),
-            userMessage: 'ファイル操作中にエラーが発生しました。',
-            cause: e instanceof Error ? e : new Error(String(e)),
-          }),
-        ),
-      ),
+      service
+        .openElectronLogOnExplorer()
+        .pipe(Effect.mapError(mapToFileOperationError)),
     );
     return true;
   }),
   openDirOnExplorer: procedure.input(z.string()).mutation(async (ctx) => {
     await runEffect(
-      service.openDirOnExplorer(ctx.input).pipe(
-        Effect.mapError((e) =>
-          UserFacingError.withStructuredInfo({
-            code: ERROR_CODES.UNKNOWN,
-            category: ERROR_CATEGORIES.UNKNOWN_ERROR,
-            message: String(e),
-            userMessage: 'ファイル操作中にエラーが発生しました。',
-            cause: e instanceof Error ? e : new Error(String(e)),
-          }),
-        ),
-      ),
+      service
+        .openDirOnExplorer(ctx.input)
+        .pipe(Effect.mapError(mapToFileOperationError)),
     );
     return true;
   }),
@@ -234,15 +211,7 @@ export const router = trpcRouter({
             // キャンセルは silent（ユーザーの意図的な操作）
             return Effect.void;
           }
-          return Effect.fail(
-            UserFacingError.withStructuredInfo({
-              code: ERROR_CODES.UNKNOWN,
-              category: ERROR_CATEGORIES.UNKNOWN_ERROR,
-              message: String(e),
-              userMessage: 'ファイル操作中にエラーが発生しました。',
-              cause: e instanceof Error ? e : new Error(String(e)),
-            }),
-          );
+          return Effect.fail(mapToFileOperationError({ message: String(e) }));
         }),
       ),
     );

--- a/electron/api.ts
+++ b/electron/api.ts
@@ -211,7 +211,9 @@ export const router = trpcRouter({
             // キャンセルは silent（ユーザーの意図的な操作）
             return Effect.void;
           }
-          return Effect.fail(mapToFileOperationError({ message: String(e) }));
+          // 元のエラーオブジェクトをそのまま mapToFileOperationError に渡し、
+          // toUserFacing 側で `cause` として元の Error/スタックトレースを保持する
+          return Effect.fail(mapToFileOperationError(e));
         }),
       ),
     );

--- a/electron/lib/dbHelper.ts
+++ b/electron/lib/dbHelper.ts
@@ -5,35 +5,18 @@ import { type DBQueueError, getDBQueue } from './dbQueue';
 /**
  * データベースアクセスのユーティリティ関数を提供するモジュール
  * - DBQueueを使用して安全にデータベースアクセスを行う
- * - トランザクション処理やバッチ処理をサポート
+ * - 読み取り専用クエリ実行と任意の Promise タスクのキューイングを提供
  */
 
 /**
- * データベースヘルパーのエラー型
+ * データベースヘルパーのエラー型。
+ *
+ * `BATCH_OPERATION_FAILED` は `vrchatWorldJoinLog/service.ts` で
+ * 複数件の登録が部分失敗した場合に使用される。
  */
 export type DBHelperError =
-  | { type: 'TRANSACTION_FAILED'; message: string }
   | { type: 'BATCH_OPERATION_FAILED'; message: string }
-  | { type: 'RETRY_FAILED'; message: string }
   | DBQueueError;
-
-// /**
-//  * トランザクションを使用してデータベース操作を実行する
-//  * @param callback トランザクションを使用するコールバック関数
-//  * @returns コールバック関数の実行結果
-//  */
-// export async function withTransaction<T>(
-//   callback: (transaction: Transaction) => Promise<T>,
-// ): Promise<Result<T, DBHelperError>> {
-//   const result = await getDBQueue().transaction(callback);
-
-//   if (result.isErr()) {
-//     // DBQueueErrorをそのまま返す
-//     return result as Result<T, DBHelperError>;
-//   }
-
-//   return result as Result<T, DBHelperError>;
-// }
 
 // 読み取り用のキュー設定
 const READ_QUEUE_CONFIG = {
@@ -57,96 +40,6 @@ export function executeQuery(
   >;
 }
 
-// /**
-//  * 複数のデータベース操作をバッチ処理として実行する
-//  * すべての操作は同一トランザクション内で実行される
-//  * @param operations 実行する操作の配列
-//  * @returns 各操作の実行結果の配列
-//  */
-// export async function executeBatch<T>(
-//   operations: ((transaction: Transaction) => Promise<T>)[],
-// ): Promise<Result<T[], DBHelperError>> {
-//   const transactionResult = await withTransaction(async (transaction) => {
-//     const results: T[] = [];
-//     for (const operation of operations) {
-//       try {
-//         const result = await operation(transaction);
-//         results.push(result);
-//       } catch (error) {
-//         logger.error({
-//           message: 'バッチ処理中にエラーが発生しました',
-//           stack: error instanceof Error ? error : new Error(String(error)),
-//         });
-//         throw error; // トランザクション全体がロールバックされる
-//       }
-//     }
-//     return results;
-//   });
-
-//   if (transactionResult.isErr()) {
-//     return err({
-//       type: 'BATCH_OPERATION_FAILED',
-//       message: `バッチ処理に失敗しました: ${transactionResult.error.message}`,
-//     });
-//   }
-
-//   return transactionResult;
-// }
-
-// /**
-//  * リトライ機能付きでデータベース操作を実行する
-//  * @param operation 実行する操作
-//  * @param options リトライオプション
-//  * @returns 操作の実行結果
-//  */
-// export async function withRetry<T>(
-//   operation: () => Promise<Result<T, DBHelperError>>,
-//   options: {
-//     maxRetries?: number;
-//     retryDelay?: number;
-//     shouldRetry?: (error: DBHelperError) => boolean;
-//   } = {},
-// ): Promise<Result<T, DBHelperError>> {
-//   const maxRetries = options.maxRetries ?? 3;
-//   const retryDelay = options.retryDelay ?? 1000;
-//   const shouldRetry = options.shouldRetry ?? ((_error) => true);
-
-//   let lastError: DBHelperError = {
-//     type: 'RETRY_FAILED',
-//     message: '不明なエラーが発生しました',
-//   };
-
-//   for (let attempt = 0; attempt < maxRetries; attempt++) {
-//     const result = await operation();
-
-//     if (result.isOk()) {
-//       return result;
-//     }
-
-//     lastError = result.error;
-
-//     // 最後の試行でエラーが発生した場合はエラーを返す
-//     if (attempt === maxRetries - 1) {
-//       break;
-//     }
-
-//     // リトライ条件を満たさない場合はエラーを返す
-//     if (!shouldRetry(lastError)) {
-//       break;
-//     }
-
-//     logger.debug(
-//       `データベース操作を再試行します (${attempt + 1}/${maxRetries})`,
-//     );
-//     await new Promise<void>((resolve) => { setTimeout(resolve, retryDelay); });
-//   }
-
-//   return err({
-//     type: 'RETRY_FAILED',
-//     message: `リトライ後も操作に失敗しました: ${lastError.message}`,
-//   });
-// }
-
 /**
  * データベースキューにタスクを追加して実行する
  * @param operation 実行する操作
@@ -160,41 +53,3 @@ export function enqueueTask<T>(
 
   return dbQueue.addWithResult(operation) as Effect.Effect<T, DBHelperError>;
 }
-
-// /**
-//  * データベースキューの状態を取得する
-//  * @returns キューの状態情報
-//  */
-// export function getQueueStatus(): {
-//   size: number;
-//   pending: number;
-//   isIdle: boolean;
-// } {
-//   const queue = getDBQueue();
-//   return {
-//     size: queue.size,
-//     pending: queue.pending,
-//     isIdle: queue.isIdle,
-//   };
-// }
-
-// /**
-//  * データベースキューが空になるまで待機する
-//  */
-// export async function waitForQueueIdle(): Promise<void> {
-//   return getDBQueue().onIdle();
-// }
-
-// /**
-//  * データベースキューを一時停止する
-//  */
-// export function pauseQueue(): void {
-//   getDBQueue().pause();
-// }
-
-// /**
-//  * データベースキューを再開する
-//  */
-// export function startQueue(): void {
-//   getDBQueue().start();
-// }

--- a/electron/lib/electronModules.ts
+++ b/electron/lib/electronModules.ts
@@ -20,3 +20,36 @@ export const getShell = () => getElectron().shell;
 export const getDialog = () => getElectron().dialog;
 export const getClipboard = () => getElectron().clipboard;
 export const getNativeImage = () => getElectron().nativeImage;
+
+/**
+ * Electron 環境であれば `fn(app)` を、そうでなければ `fallback` を返す。
+ *
+ * 背景: 「Electron 前提だがテスト環境でも動く必要がある」モジュール（logger,
+ * wrappedApp, exportService, vrchatPhoto.service, renderSvg）で
+ * 同じ try-catch + `require('electron')` の遅延ロードパターンが重複していた。
+ * このヘルパーで集約することで:
+ *   - `effect-lint-allow-try-catch` 注釈付き try-catch を削減
+ *   - フォールバック値の組み立て方を呼び出し側に委ねる（高階関数）
+ *
+ * @param fallback テスト/非 Electron 環境で返す値
+ * @param fn Electron 環境で `app` を受けて結果を計算する関数
+ *
+ * @example
+ * ```typescript
+ * const logPath = withElectronApp(
+ *   '/tmp/test-logs/app.log',
+ *   (app) => path.join(app.getPath('logs'), 'app.log'),
+ * );
+ * ```
+ */
+export const withElectronApp = <T>(
+  fallback: T,
+  fn: (app: Electron.App) => T,
+): T => {
+  // effect-lint-allow-try-catch: Electron 環境検出パターン
+  try {
+    return fn(getElectron().app);
+  } catch {
+    return fallback;
+  }
+};

--- a/electron/lib/errorMapping.test.ts
+++ b/electron/lib/errorMapping.test.ts
@@ -1,0 +1,147 @@
+import { Effect, Exit } from 'effect';
+import { describe, expect, it } from 'vitest';
+
+import {
+  mapByTag,
+  mapToFileOperationError,
+  mapToOpenPathError,
+  mapToUnknownError,
+  toError,
+  toUserFacing,
+} from './errorMapping';
+import { ERROR_CATEGORIES, ERROR_CODES, UserFacingError } from './errors';
+
+describe('toError', () => {
+  it('Error はそのまま返す', () => {
+    const original = new Error('boom');
+    expect(toError(original)).toBe(original);
+  });
+
+  it('文字列は Error にラップする', () => {
+    const result = toError('boom');
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe('boom');
+  });
+
+  it('オブジェクトは toString で文字列化', () => {
+    const result = toError({ foo: 'bar' });
+    expect(result).toBeInstanceOf(Error);
+  });
+});
+
+describe('toUserFacing', () => {
+  it('指定したコード/カテゴリ/ユーザーメッセージで変換する', () => {
+    const map = toUserFacing<{ message: string }>({
+      code: ERROR_CODES.DATABASE_ERROR,
+      category: ERROR_CATEGORIES.DATABASE_ERROR,
+      userMessage: 'DBエラー',
+    });
+
+    const result = map({ message: 'connection failed' });
+
+    expect(result).toBeInstanceOf(UserFacingError);
+    expect(result.code).toBe(ERROR_CODES.DATABASE_ERROR);
+    expect(result.category).toBe(ERROR_CATEGORIES.DATABASE_ERROR);
+    expect(result.userMessage).toBe('DBエラー');
+    expect(result.errorInfo?.message).toBe('DBエラー (connection failed)');
+  });
+
+  it('userMessage を関数で動的生成できる', () => {
+    const map = toUserFacing<{ message: string }>({
+      userMessage: (e) => `アップデートに失敗しました: ${e.message}`,
+    });
+
+    const result = map({ message: 'network down' });
+
+    expect(result.userMessage).toBe('アップデートに失敗しました: network down');
+  });
+
+  it('cause に元エラーを保持する', () => {
+    const original = new Error('原因');
+    const map = toUserFacing<Error>({ userMessage: 'X' });
+
+    const result = map(original);
+
+    expect(result.errorInfo?.cause).toBe(original);
+  });
+
+  it('Effect.mapError と組み合わせて E チャネルを変換できる', async () => {
+    const failing = Effect.fail<{ message: string }>({ message: 'x' });
+    const mapped = failing.pipe(
+      Effect.mapError(toUserFacing<{ message: string }>({ userMessage: 'Y' })),
+    );
+
+    const exit = await Effect.runPromiseExit(mapped);
+    expect(Exit.isFailure(exit)).toBe(true);
+  });
+});
+
+describe('プリセットマッパー', () => {
+  it('mapToFileOperationError は UNKNOWN/UNKNOWN_ERROR で「ファイル操作中…」', () => {
+    const result = mapToFileOperationError({ message: 'EACCES' });
+
+    expect(result.code).toBe(ERROR_CODES.UNKNOWN);
+    expect(result.category).toBe(ERROR_CATEGORIES.UNKNOWN_ERROR);
+    expect(result.userMessage).toBe('ファイル操作中にエラーが発生しました。');
+  });
+
+  it('mapToOpenPathError は FILE_NOT_FOUND で「ファイルを開けませんでした」', () => {
+    const result = mapToOpenPathError({ message: 'no such path' });
+
+    expect(result.code).toBe(ERROR_CODES.FILE_NOT_FOUND);
+    expect(result.category).toBe(ERROR_CATEGORIES.FILE_NOT_FOUND);
+    expect(result.userMessage).toBe('ファイルを開けませんでした。');
+  });
+
+  it('mapToUnknownError は userMessage を任意指定可能', () => {
+    const map = mapToUnknownError('画像生成中にエラーが発生しました。');
+    const result = map({ message: 'svg parse error' });
+
+    expect(result.userMessage).toBe('画像生成中にエラーが発生しました。');
+  });
+});
+
+describe('mapByTag', () => {
+  type SyncError =
+    | { _tag: 'LogFileDirNotFound'; message: string }
+    | { _tag: 'LogFilesNotFound'; message: string }
+    | { _tag: 'GenericError'; message: string };
+
+  const map = mapByTag<SyncError>(
+    {
+      LogFileDirNotFound: () =>
+        UserFacingError.withStructuredInfo({
+          code: ERROR_CODES.VRCHAT_DIRECTORY_SETUP_REQUIRED,
+          category: ERROR_CATEGORIES.SETUP_REQUIRED,
+          message: 'dir not found',
+          userMessage: 'ディレクトリ未設定',
+        }),
+      LogFilesNotFound: () =>
+        UserFacingError.withStructuredInfo({
+          code: ERROR_CODES.FILE_NOT_FOUND,
+          category: ERROR_CATEGORIES.FILE_NOT_FOUND,
+          message: 'files not found',
+          userMessage: 'ファイル未検出',
+        }),
+    },
+    mapToUnknownError('ログ同期中にエラーが発生しました。'),
+  );
+
+  it('登録した tag は対応する変換が呼ばれる', () => {
+    const result = map({ _tag: 'LogFileDirNotFound', message: 'm' });
+    expect(result.code).toBe(ERROR_CODES.VRCHAT_DIRECTORY_SETUP_REQUIRED);
+    expect(result.userMessage).toBe('ディレクトリ未設定');
+  });
+
+  it('未登録の tag は fallback が呼ばれる', () => {
+    const result = map({ _tag: 'GenericError', message: 'oops' });
+    expect(result.code).toBe(ERROR_CODES.UNKNOWN);
+    expect(result.userMessage).toBe('ログ同期中にエラーが発生しました。');
+  });
+
+  it('fallback 省略時はデフォルトの「予期しないエラー」', () => {
+    const mapNoFallback = mapByTag<SyncError>({});
+    const result = mapNoFallback({ _tag: 'GenericError', message: 'x' });
+    expect(result.userMessage).toBe('予期しないエラーが発生しました。');
+  });
+});

--- a/electron/lib/errorMapping.test.ts
+++ b/electron/lib/errorMapping.test.ts
@@ -27,6 +27,12 @@ describe('toError', () => {
     const result = toError({ foo: 'bar' });
     expect(result).toBeInstanceOf(Error);
   });
+
+  it('Tagged Error 風の plain object は message を保持する', () => {
+    const tagged = { _tag: 'MyError', message: '原因メッセージ' };
+    const result = toError(tagged);
+    expect(result.message).toBe('原因メッセージ');
+  });
 });
 
 describe('toUserFacing', () => {

--- a/electron/lib/errorMapping.test.ts
+++ b/electron/lib/errorMapping.test.ts
@@ -43,7 +43,8 @@ describe('toUserFacing', () => {
     expect(result.code).toBe(ERROR_CODES.DATABASE_ERROR);
     expect(result.category).toBe(ERROR_CATEGORIES.DATABASE_ERROR);
     expect(result.userMessage).toBe('DBエラー');
-    expect(result.errorInfo?.message).toBe('DBエラー (connection failed)');
+    // message のデフォルトは raw e.message（旧コード互換）
+    expect(result.errorInfo?.message).toBe('connection failed');
   });
 
   it('userMessage を関数で動的生成できる', () => {

--- a/electron/lib/errorMapping.ts
+++ b/electron/lib/errorMapping.ts
@@ -23,38 +23,6 @@ import {
 } from './errors';
 
 /**
- * 任意の値を Error に正規化する。
- *
- * UserFacingError の `cause` にスタックトレースを残すため、
- * Error 以外（string、tagged error の plain object など）はラップする。
- *
- * `e instanceof Error ? e : new Error(String(e))` のイディオムが
- * 各所で重複していたため SSOT 化。
- */
-export const toError = (e: unknown): Error =>
-  e instanceof Error ? e : new Error(String(e));
-
-/**
- * `toUserFacing` のオプション。
- *
- * `userMessage` / `message` を関数で受けることで、
- * 元エラーの内容を埋め込んだメッセージ生成（例: `アップデートに失敗しました: ${e.message}`）に対応する。
- *
- * E は任意の型を許容する（string literal の Tagged Error も含む）。
- */
-export interface UserFacingFactoryOptions<E> {
-  code?: ErrorCode;
-  category?: ErrorCategory;
-  /** ユーザー向けメッセージ。文字列 or 元エラーから生成する関数 */
-  userMessage: string | ((e: E) => string);
-  /**
-   * 内部 message（Sentry/ログ用）。省略時は元エラーの `message` プロパティ (=`e.message`) を
-   * そのまま使う。旧コードの `message: e.message` 相当を維持するためのデフォルト。
-   */
-  message?: string | ((e: E) => string);
-}
-
-/**
  * 任意の値からメッセージ文字列を取り出す。
  *
  * `{ message: string }` を持つオブジェクトはそのプロパティを、
@@ -75,6 +43,38 @@ const extractErrorMessage = (e: unknown): string => {
   }
   return String(e);
 };
+
+/**
+ * 任意の値を Error に正規化する。
+ *
+ * UserFacingError の `cause` にスタックトレースを残すため、
+ * Error 以外（string、Tagged Error の plain object など）はラップする。
+ * Tagged Error の plain object でも `message` フィールドを保持するため、
+ * `extractErrorMessage` 経由で意味のあるメッセージを抜き出して Error 化する
+ * (旧 `String(e)` だと `[object Object]` になりメッセージが失われていた)。
+ */
+export const toError = (e: unknown): Error =>
+  e instanceof Error ? e : new Error(extractErrorMessage(e));
+
+/**
+ * `toUserFacing` のオプション。
+ *
+ * `userMessage` / `message` を関数で受けることで、
+ * 元エラーの内容を埋め込んだメッセージ生成（例: `アップデートに失敗しました: ${e.message}`）に対応する。
+ *
+ * E は任意の型を許容する（string literal の Tagged Error も含む）。
+ */
+export interface UserFacingFactoryOptions<E> {
+  code?: ErrorCode;
+  category?: ErrorCategory;
+  /** ユーザー向けメッセージ。文字列 or 元エラーから生成する関数 */
+  userMessage: string | ((e: E) => string);
+  /**
+   * 内部 message（Sentry/ログ用）。省略時は元エラーの `message` プロパティ (=`e.message`) を
+   * そのまま使う。旧コードの `message: e.message` 相当を維持するためのデフォルト。
+   */
+  message?: string | ((e: E) => string);
+}
 
 /**
  * `Effect.mapError` 用の UserFacingError 変換ファクトリ。
@@ -185,12 +185,21 @@ export const mapToUnknownError = (
  */
 export const mapByTag =
   <E extends { _tag?: string; message: string }>(
-    patterns: Record<string, (e: E) => UserFacingError>,
+    patterns: Partial<
+      Record<NonNullable<E['_tag']>, (e: E) => UserFacingError>
+    >,
     fallback: (e: E) => UserFacingError = mapToUnknownError(
       '予期しないエラーが発生しました。',
     ),
   ) =>
   (e: E): UserFacingError => {
-    const handler = typeof e._tag === 'string' ? patterns[e._tag] : undefined;
+    // 型上は `Partial<Record<NonNullable<E['_tag']>, ...>>` だが、
+    // ランタイムでは任意の string キーで lookup したいため一度緩めて参照する
+    const handler =
+      typeof e._tag === 'string'
+        ? (patterns as Record<string, ((e: E) => UserFacingError) | undefined>)[
+            e._tag
+          ]
+        : undefined;
     return handler ? handler(e) : fallback(e);
   };

--- a/electron/lib/errorMapping.ts
+++ b/electron/lib/errorMapping.ts
@@ -14,8 +14,6 @@
  * @see electron/lib/effectTRPC.ts - runEffect (tRPC 実行境界)
  */
 
-import { match, P } from 'ts-pattern';
-
 import {
   ERROR_CATEGORIES,
   type ErrorCategory,
@@ -49,7 +47,10 @@ export interface UserFacingFactoryOptions<E> {
   category?: ErrorCategory;
   /** ユーザー向けメッセージ。文字列 or 元エラーから生成する関数 */
   userMessage: string | ((e: E) => string);
-  /** 内部 message。省略時は `${userMessage} (${e.message})` を生成 */
+  /**
+   * 内部 message（Sentry/ログ用）。省略時は元エラーの `message` プロパティ (=`e.message`) を
+   * そのまま使う。旧コードの `message: e.message` 相当を維持するためのデフォルト。
+   */
   message?: string | ((e: E) => string);
 }
 
@@ -58,13 +59,19 @@ export interface UserFacingFactoryOptions<E> {
  *
  * `{ message: string }` を持つオブジェクトはそのプロパティを、
  * 文字列はそのまま、それ以外は `String()` で変換する。
+ *
+ * `e.message` が `undefined` のケースで `"undefined"` 文字列が
+ * 表示に紛れ込まないよう、string 以外は `String(e)` にフォールバックする。
  */
 const extractErrorMessage = (e: unknown): string => {
   if (typeof e === 'string') {
     return e;
   }
   if (e && typeof e === 'object' && 'message' in e) {
-    return String((e as { message: unknown }).message);
+    const msg = (e as { message: unknown }).message;
+    if (typeof msg === 'string') {
+      return msg;
+    }
   }
   return String(e);
 };
@@ -87,22 +94,24 @@ const resolveTemplate = <E>(
   template: string | ((e: E) => string) | undefined,
   fallback: string,
   e: E,
-): string =>
-  match(template)
-    .with(P.string, (s) => s)
-    .with(P.nullish, () => fallback)
-    .otherwise((fn) => fn(e));
+): string => {
+  if (template === undefined) {
+    return fallback;
+  }
+  if (typeof template === 'string') {
+    return template;
+  }
+  return template(e);
+};
 
 export const toUserFacing =
   <E>(opts: UserFacingFactoryOptions<E>) =>
   (e: E): UserFacingError => {
     const userMessage = resolveTemplate(opts.userMessage, '', e);
+    // 旧コード互換のため message のデフォルトは raw `e.message`
+    // （内部ログや Sentry で元のエラー文面を失わないため）
     const errorMessage = extractErrorMessage(e);
-    const message = resolveTemplate(
-      opts.message,
-      `${userMessage} (${errorMessage})`,
-      e,
-    );
+    const message = resolveTemplate(opts.message, errorMessage, e);
     return UserFacingError.withStructuredInfo({
       code: opts.code ?? ERROR_CODES.UNKNOWN,
       category: opts.category ?? ERROR_CATEGORIES.UNKNOWN_ERROR,
@@ -157,8 +166,11 @@ export const mapToUnknownError = (
  * `logSyncController` のように複数の Tagged Error をまとめて変換する箇所で、
  * `match(e._tag).with(...).otherwise(...)` のボイラープレートを排除する。
  *
- * `_tag` は optional で受け、未定義のエラー（旧来の `Error` 派生クラス等）は
- * 自動で `fallback` に流れる。
+ * 対応するエラー型: `Data.TaggedError` 由来の `_tag: string` を持つもの。
+ * `_tag` は optional で受け、未定義のエラー（旧来の `Error` 派生クラスや
+ * `code` フィールドのみのエラー）は自動で `fallback` に流れる。
+ * その種のエラーを個別分岐したい場合は `match(e).with({ code: 'X' }, ...)` のような
+ * 専用ハンドラを別途用意するか、まずエラー型を `Data.TaggedError` に移行すること。
  *
  * @param patterns - `_tag` をキーとした変換関数のマップ。未列挙の tag は `fallback` が処理。
  * @param fallback - patterns に一致しなかった場合のデフォルト変換。省略時は UNKNOWN/UNKNOWN_ERROR。
@@ -180,7 +192,5 @@ export const mapByTag =
   ) =>
   (e: E): UserFacingError => {
     const handler = typeof e._tag === 'string' ? patterns[e._tag] : undefined;
-    return match(handler)
-      .with(undefined, () => fallback(e))
-      .otherwise((h) => h(e));
+    return handler ? handler(e) : fallback(e);
   };

--- a/electron/lib/errorMapping.ts
+++ b/electron/lib/errorMapping.ts
@@ -1,0 +1,186 @@
+/**
+ * Effect.mapError と組み合わせる UserFacingError 変換ヘルパー
+ *
+ * 背景: コントローラー層で
+ * `Effect.mapError(e => UserFacingError.withStructuredInfo({ code, category, message, userMessage, cause: ... }))`
+ * のボイラープレートが各 tRPC ルーターで重複していた。
+ * SSOT 化することで「同じユーザーメッセージが複数箇所に散在 → メッセージ修正漏れ」のリスクを排除する。
+ *
+ * 使い分け:
+ * - 単一エラー型を変換: `toUserFacing()` / プリセット (`mapToFileOperationError` 等)
+ * - 複数 tag を分岐: `mapByTag()`（ts-pattern の `match` + `_tag` 判定をラップ）
+ *
+ * @see electron/lib/errors.ts - UserFacingError 定義
+ * @see electron/lib/effectTRPC.ts - runEffect (tRPC 実行境界)
+ */
+
+import { match, P } from 'ts-pattern';
+
+import {
+  ERROR_CATEGORIES,
+  type ErrorCategory,
+  ERROR_CODES,
+  type ErrorCode,
+  UserFacingError,
+} from './errors';
+
+/**
+ * 任意の値を Error に正規化する。
+ *
+ * UserFacingError の `cause` にスタックトレースを残すため、
+ * Error 以外（string、tagged error の plain object など）はラップする。
+ *
+ * `e instanceof Error ? e : new Error(String(e))` のイディオムが
+ * 各所で重複していたため SSOT 化。
+ */
+export const toError = (e: unknown): Error =>
+  e instanceof Error ? e : new Error(String(e));
+
+/**
+ * `toUserFacing` のオプション。
+ *
+ * `userMessage` / `message` を関数で受けることで、
+ * 元エラーの内容を埋め込んだメッセージ生成（例: `アップデートに失敗しました: ${e.message}`）に対応する。
+ *
+ * E は任意の型を許容する（string literal の Tagged Error も含む）。
+ */
+export interface UserFacingFactoryOptions<E> {
+  code?: ErrorCode;
+  category?: ErrorCategory;
+  /** ユーザー向けメッセージ。文字列 or 元エラーから生成する関数 */
+  userMessage: string | ((e: E) => string);
+  /** 内部 message。省略時は `${userMessage} (${e.message})` を生成 */
+  message?: string | ((e: E) => string);
+}
+
+/**
+ * 任意の値からメッセージ文字列を取り出す。
+ *
+ * `{ message: string }` を持つオブジェクトはそのプロパティを、
+ * 文字列はそのまま、それ以外は `String()` で変換する。
+ */
+const extractErrorMessage = (e: unknown): string => {
+  if (typeof e === 'string') {
+    return e;
+  }
+  if (e && typeof e === 'object' && 'message' in e) {
+    return String((e as { message: unknown }).message);
+  }
+  return String(e);
+};
+
+/**
+ * `Effect.mapError` 用の UserFacingError 変換ファクトリ。
+ *
+ * @example
+ * ```typescript
+ * const mapMyError = toUserFacing<MyError>({
+ *   code: ERROR_CODES.DATABASE_ERROR,
+ *   category: ERROR_CATEGORIES.DATABASE_ERROR,
+ *   userMessage: 'データの取得に失敗しました。',
+ * });
+ *
+ * service.getData().pipe(Effect.mapError(mapMyError));
+ * ```
+ */
+const resolveTemplate = <E>(
+  template: string | ((e: E) => string) | undefined,
+  fallback: string,
+  e: E,
+): string =>
+  match(template)
+    .with(P.string, (s) => s)
+    .with(P.nullish, () => fallback)
+    .otherwise((fn) => fn(e));
+
+export const toUserFacing =
+  <E>(opts: UserFacingFactoryOptions<E>) =>
+  (e: E): UserFacingError => {
+    const userMessage = resolveTemplate(opts.userMessage, '', e);
+    const errorMessage = extractErrorMessage(e);
+    const message = resolveTemplate(
+      opts.message,
+      `${userMessage} (${errorMessage})`,
+      e,
+    );
+    return UserFacingError.withStructuredInfo({
+      code: opts.code ?? ERROR_CODES.UNKNOWN,
+      category: opts.category ?? ERROR_CATEGORIES.UNKNOWN_ERROR,
+      message,
+      userMessage,
+      cause: toError(e),
+    });
+  };
+
+/**
+ * 汎用ファイル操作エラー → UserFacingError。
+ *
+ * `electronUtilController` / `api.ts` の openPathOnExplorer 等で重複していた
+ * 「ファイル操作中にエラーが発生しました。」のマッパー。
+ */
+export const mapToFileOperationError = toUserFacing<{ message: string }>({
+  userMessage: 'ファイル操作中にエラーが発生しました。',
+});
+
+/**
+ * パスオープン失敗エラー → UserFacingError。
+ *
+ * `OpenPathFailed` を「ファイルを開けませんでした」として表示する用途。
+ * `electronUtilController` で重複していたパターン。
+ */
+export const mapToOpenPathError = toUserFacing<{ message: string }>({
+  code: ERROR_CODES.FILE_NOT_FOUND,
+  category: ERROR_CATEGORIES.FILE_NOT_FOUND,
+  userMessage: 'ファイルを開けませんでした。',
+});
+
+/**
+ * 汎用 UNKNOWN エラー → UserFacingError ファクトリ。
+ *
+ * `userMessage` だけ指定したい場合のショートハンド。
+ * `imageGeneratorController` / `vrchatLogController` 等のドメイン固有マッパーから利用。
+ *
+ * @example
+ * ```typescript
+ * const mapImageGenerationError = mapToUnknownError(
+ *   '画像生成中にエラーが発生しました。',
+ * );
+ * ```
+ */
+export const mapToUnknownError = (
+  userMessage: string,
+): (<E>(e: E) => UserFacingError) => toUserFacing({ userMessage });
+
+/**
+ * Tagged Error の `_tag` で分岐し、対応するユーザーメッセージに変換する。
+ *
+ * `logSyncController` のように複数の Tagged Error をまとめて変換する箇所で、
+ * `match(e._tag).with(...).otherwise(...)` のボイラープレートを排除する。
+ *
+ * `_tag` は optional で受け、未定義のエラー（旧来の `Error` 派生クラス等）は
+ * 自動で `fallback` に流れる。
+ *
+ * @param patterns - `_tag` をキーとした変換関数のマップ。未列挙の tag は `fallback` が処理。
+ * @param fallback - patterns に一致しなかった場合のデフォルト変換。省略時は UNKNOWN/UNKNOWN_ERROR。
+ *
+ * @example
+ * ```typescript
+ * const mapSyncError = mapByTag<MySyncError>({
+ *   LogFileDirNotFound: () => UserFacingError.withStructuredInfo({...}),
+ *   LogFilesNotFound: () => UserFacingError.withStructuredInfo({...}),
+ * }, mapToUnknownError('ログ同期中にエラーが発生しました。'));
+ * ```
+ */
+export const mapByTag =
+  <E extends { _tag?: string; message: string }>(
+    patterns: Record<string, (e: E) => UserFacingError>,
+    fallback: (e: E) => UserFacingError = mapToUnknownError(
+      '予期しないエラーが発生しました。',
+    ),
+  ) =>
+  (e: E): UserFacingError => {
+    const handler = typeof e._tag === 'string' ? patterns[e._tag] : undefined;
+    return match(handler)
+      .with(undefined, () => fallback(e))
+      .otherwise((h) => h(e));
+  };

--- a/electron/lib/logger.ts
+++ b/electron/lib/logger.ts
@@ -1,27 +1,18 @@
 import { captureException, captureMessage } from '@sentry/electron/main';
 import { Effect, Either } from 'effect';
-import type Electron from 'electron';
 import * as log from 'electron-log';
 import path from 'pathe';
 import { stackWithCauses } from 'pony-cause';
 import { match, P } from 'ts-pattern';
 
 import { getSettingStore } from '../module/settingStore';
+import { withElectronApp } from './electronModules';
 import { UserFacingError } from './errors';
 
-// ログファイルパスを遅延評価する
-const getLogFilePath = (): string => {
-  // effect-lint-allow-try-catch: Electron 環境検出パターン
-  try {
-    const { app } = require('electron') as typeof Electron;
-    return path.join(app.getPath('logs'), 'app.log');
-  } catch {
-    // テストまたは非Electron環境
-    return path.join(__dirname, 'test-app.log');
-  }
-};
-
-const logFilePath = getLogFilePath();
+const logFilePath = withElectronApp(
+  path.join(__dirname, 'test-app.log'),
+  (app) => path.join(app.getPath('logs'), 'app.log'),
+);
 
 log.transports.file.resolvePathFn = () => logFilePath;
 
@@ -29,17 +20,7 @@ log.transports.file.resolvePathFn = () => logFilePath;
 log.transports.file.maxSize = 5 * 1024 * 1024;
 
 // ログレベルの設定
-const getIsProduction = (): boolean => {
-  // effect-lint-allow-try-catch: Electron 環境検出パターン
-  try {
-    const { app } = require('electron') as typeof Electron;
-    return app.isPackaged;
-  } catch {
-    return false;
-  }
-};
-
-const isProduction = getIsProduction();
+const isProduction = withElectronApp(false, (app) => app.isPackaged);
 log.transports.file.level = isProduction ? 'info' : 'debug';
 log.transports.console.level = isProduction ? 'warn' : 'debug';
 

--- a/electron/lib/wrappedApp.ts
+++ b/electron/lib/wrappedApp.ts
@@ -1,8 +1,20 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+
 import { withElectronApp } from './electronModules';
+
+/**
+ * テスト/非 Electron 環境向けの userData フォールバックパス。
+ * `os.tmpdir()` を使うことで OS 非依存（旧 `/tmp/test-user-data` は Windows で機能しなかった）。
+ */
+const TEST_USER_DATA_PATH = path.join(
+  os.tmpdir(),
+  'vrchat-albums-test-user-data',
+);
 
 /**
  * Get the path to the user data directory.
  * ex. C:\Users\username\AppData\Roaming\app-name
  */
 export const getAppUserDataPath = () =>
-  withElectronApp('/tmp/test-user-data', (app) => app.getPath('userData'));
+  withElectronApp(TEST_USER_DATA_PATH, (app) => app.getPath('userData'));

--- a/electron/lib/wrappedApp.ts
+++ b/electron/lib/wrappedApp.ts
@@ -1,23 +1,8 @@
-import type Electron from 'electron';
+import { withElectronApp } from './electronModules';
+
 /**
  * Get the path to the user data directory.
  * ex. C:\Users\username\AppData\Roaming\app-name
  */
-export const getAppUserDataPath = () => {
-  // effect-lint-allow-try-catch: Electron 環境検出パターン
-  try {
-    const { app } = require('electron') as typeof Electron;
-    return app.getPath('userData');
-  } catch {
-    // テストまたは非Electron環境
-    return '/tmp/test-user-data';
-  }
-};
-
-// /**
-//  * Get the path to the app directory.
-//  * ex. C:\Program Files\app-name
-//  */
-// export const getAppPath = () => {
-//   return app.getAppPath();
-// };
+export const getAppUserDataPath = () =>
+  withElectronApp('/tmp/test-user-data', (app) => app.getPath('userData'));

--- a/electron/module/electronUtil/controller/electronUtilController.ts
+++ b/electron/module/electronUtil/controller/electronUtilController.ts
@@ -9,55 +9,13 @@ import { reloadMainWindow } from '../../../electronUtil';
 import { runEffect } from '../../../lib/effectTRPC';
 import { getClipboard } from '../../../lib/electronModules';
 import {
-  ERROR_CATEGORIES,
-  ERROR_CODES,
-  UserFacingError,
-} from '../../../lib/errors';
+  mapToFileOperationError,
+  mapToOpenPathError,
+} from '../../../lib/errorMapping';
 import * as exiftool from '../../../lib/wrappedExifTool';
-import type {
-  DownloadImageError,
-  FileIOError,
-  OpenPathFailed,
-} from '../errors';
 import { eventEmitter, procedure, router as trpcRouter } from './../../../trpc';
 import { DirectoryPathSchema } from './../../../valueObjects/index';
 import * as utilsService from './../service';
-
-/**
- * DownloadImageError → UserFacingError 変換ヘルパー
- */
-const mapDownloadImageError = (e: DownloadImageError) =>
-  UserFacingError.withStructuredInfo({
-    code: ERROR_CODES.UNKNOWN,
-    category: ERROR_CATEGORIES.UNKNOWN_ERROR,
-    message: `File operation failed: ${e.message}`,
-    userMessage: 'ファイル操作中にエラーが発生しました。',
-    cause: e,
-  });
-
-/**
- * FileIOError → UserFacingError 変換ヘルパー
- */
-const mapFileIOError = (e: FileIOError) =>
-  UserFacingError.withStructuredInfo({
-    code: ERROR_CODES.UNKNOWN,
-    category: ERROR_CATEGORIES.UNKNOWN_ERROR,
-    message: `File operation failed: ${e.message}`,
-    userMessage: 'ファイル操作中にエラーが発生しました。',
-    cause: e,
-  });
-
-/**
- * OpenPathFailed → UserFacingError 変換ヘルパー
- */
-const mapOpenPathError = (e: OpenPathFailed) =>
-  UserFacingError.withStructuredInfo({
-    code: ERROR_CODES.FILE_NOT_FOUND,
-    category: ERROR_CATEGORIES.FILE_NOT_FOUND,
-    message: `Failed to open path: ${e.message}`,
-    userMessage: 'ファイルを開けませんでした。',
-    cause: e,
-  });
 
 export const electronUtilRouter = () =>
   trpcRouter({
@@ -113,7 +71,7 @@ export const electronUtilRouter = () =>
             Effect.catchTag('OperationCanceled', () =>
               Effect.succeed(false as const),
             ),
-            Effect.mapError(mapDownloadImageError),
+            Effect.mapError(mapToFileOperationError),
           ),
         ),
       ),
@@ -179,7 +137,7 @@ export const electronUtilRouter = () =>
         runEffect(
           utilsService.copyImageByBase64(input).pipe(
             Effect.map(() => true as const),
-            Effect.mapError(mapFileIOError),
+            Effect.mapError(mapToFileOperationError),
           ),
         ),
       ),
@@ -189,7 +147,7 @@ export const electronUtilRouter = () =>
         runEffect(
           utilsService.openPhotoPathWithPhotoApp(input).pipe(
             Effect.map(() => true as const),
-            Effect.mapError(mapOpenPathError),
+            Effect.mapError(mapToOpenPathError),
           ),
         ),
       ),
@@ -214,7 +172,7 @@ export const electronUtilRouter = () =>
         runEffect(
           utilsService.openPathWithAssociatedApp(input).pipe(
             Effect.map(() => true as const),
-            Effect.mapError(mapOpenPathError),
+            Effect.mapError(mapToOpenPathError),
           ),
         ),
       ),

--- a/electron/module/imageGenerator/imageGeneratorController.ts
+++ b/electron/module/imageGenerator/imageGeneratorController.ts
@@ -2,28 +2,18 @@ import { Effect } from 'effect';
 import { z } from 'zod';
 
 import { runEffect } from '../../lib/effectTRPC';
-import {
-  ERROR_CATEGORIES,
-  ERROR_CODES,
-  UserFacingError,
-} from '../../lib/errors';
+import { mapToUnknownError } from '../../lib/errorMapping';
 import { procedure, router as trpcRouter } from '../../trpc';
-import type { ImageGenerationError } from './errors';
 import { generateSharePreview } from './service';
 
 /**
  * ImageGenerationError → UserFacingError 変換ヘルパー
  *
- * cause を含めて Sentry が元エラーを追跡可能にする
+ * cause を含めて Sentry が元エラーを追跡可能にする。
  */
-const mapImageGenerationError = (e: ImageGenerationError) =>
-  UserFacingError.withStructuredInfo({
-    code: ERROR_CODES.UNKNOWN,
-    category: ERROR_CATEGORIES.UNKNOWN_ERROR,
-    message: `Image generation failed: ${e.message}`,
-    userMessage: '画像生成中にエラーが発生しました。',
-    cause: e,
-  });
+const mapImageGenerationError = mapToUnknownError(
+  '画像生成中にエラーが発生しました。',
+);
 
 /**
  * 画像生成の tRPC ルーター

--- a/electron/module/imageGenerator/renderSvg.ts
+++ b/electron/module/imageGenerator/renderSvg.ts
@@ -25,7 +25,7 @@ let fontFilePaths: string[] = [];
  * フォント解決の優先順位:
  * 1. Electron パッケージ済み: process.resourcesPath/fonts/
  * 2. 開発環境: electron/resources/fonts/ (__dirname からの相対パス)
- * 3. テスト環境: 同じ相対パスで解決（Electron require が失敗するため catch で処理）
+ * 3. テスト環境: 同じ相対パスで解決（withElectronApp の fallback 経由）
  */
 const loadFonts = (): Effect.Effect<string[], ImageGenerationError> => {
   if (fontsLoaded) {

--- a/electron/module/imageGenerator/renderSvg.ts
+++ b/electron/module/imageGenerator/renderSvg.ts
@@ -3,9 +3,9 @@ import * as fs from 'node:fs';
 import { Transformer } from '@napi-rs/image';
 import { Resvg } from '@resvg/resvg-js';
 import { Effect } from 'effect';
-import type Electron from 'electron';
 import * as path from 'pathe';
 
+import { withElectronApp } from '../../lib/electronModules';
 import type { ImageGenerationError } from './errors';
 import {
   FontLoadFailed,
@@ -32,21 +32,16 @@ const loadFonts = (): Effect.Effect<string[], ImageGenerationError> => {
     return Effect.succeed(fontFilePaths);
   }
 
-  const fontsDir = (() => {
-    // effect-lint-allow-try-catch: Electron環境検出パターン（遅延require）
-    try {
-      const { app } = require('electron') as typeof Electron;
-      return path.join(
+  const fontsDir = withElectronApp(
+    path.join(__dirname, '../../resources/fonts'),
+    (app) =>
+      path.join(
         app.isPackaged
           ? process.resourcesPath
           : path.join(__dirname, '../../resources'),
         'fonts',
-      );
-    } catch {
-      // テスト環境または非 Electron コンテキスト
-      return path.join(__dirname, '../../resources/fonts');
-    }
-  })();
+      ),
+  );
 
   /**
    * ロード対象のフォントファイル名。

--- a/electron/module/logInfo/logInfoCointroller.ts
+++ b/electron/module/logInfo/logInfoCointroller.ts
@@ -4,11 +4,22 @@ import z from 'zod';
 
 import { BATCH_CONFIG } from '../../constants/batchConfig';
 import { runEffect, runEffectExit } from '../../lib/effectTRPC';
+import { toUserFacing } from '../../lib/errorMapping';
 import {
   ERROR_CATEGORIES,
   ERROR_CODES,
   UserFacingError,
 } from '../../lib/errors';
+
+/**
+ * ワールド参加ログ DB エラー → UserFacingError 変換。
+ * 「ワールド参加ログの取得中にエラー」を一貫して表示するための SSOT。
+ */
+const mapWorldJoinLogDbError = toUserFacing<{ message: string }>({
+  code: ERROR_CODES.DATABASE_ERROR,
+  category: ERROR_CATEGORIES.DATABASE_ERROR,
+  userMessage: 'ワールド参加ログの取得中にエラーが発生しました。',
+});
 import * as playerJoinLogService from '../VRChatPlayerJoinLogModel/playerJoinLog.service';
 import * as worldJoinLogService from '../vrchatWorldJoinLog/service';
 import { findVRChatWorldJoinLogFromPhotoList } from '../vrchatWorldJoinLogFromPhoto/service';
@@ -114,15 +125,7 @@ const getVRCWorldJoinLogList = (): Effect.Effect<
         updatedAt: joinLog.updatedAt as Date,
       })),
     ),
-    Effect.mapError((dbError) =>
-      UserFacingError.withStructuredInfo({
-        code: ERROR_CODES.DATABASE_ERROR,
-        category: ERROR_CATEGORIES.DATABASE_ERROR,
-        message: `Failed to get world join log list: ${dbError.message}`,
-        userMessage: 'ワールド参加ログの取得中にエラーが発生しました。',
-        cause: new Error(dbError.message),
-      }),
-    ),
+    Effect.mapError(mapWorldJoinLogDbError),
   );
 
 /**

--- a/electron/module/logInfo/logInfoCointroller.ts
+++ b/electron/module/logInfo/logInfoCointroller.ts
@@ -10,16 +10,6 @@ import {
   ERROR_CODES,
   UserFacingError,
 } from '../../lib/errors';
-
-/**
- * ワールド参加ログ DB エラー → UserFacingError 変換。
- * 「ワールド参加ログの取得中にエラー」を一貫して表示するための SSOT。
- */
-const mapWorldJoinLogDbError = toUserFacing<{ message: string }>({
-  code: ERROR_CODES.DATABASE_ERROR,
-  category: ERROR_CATEGORIES.DATABASE_ERROR,
-  userMessage: 'ワールド参加ログの取得中にエラーが発生しました。',
-});
 import * as playerJoinLogService from '../VRChatPlayerJoinLogModel/playerJoinLog.service';
 import * as worldJoinLogService from '../vrchatWorldJoinLog/service';
 import { findVRChatWorldJoinLogFromPhotoList } from '../vrchatWorldJoinLogFromPhoto/service';
@@ -37,6 +27,16 @@ import {
   loadLogInfoIndexFromVRChatLog,
   searchSessionsByPlayerName,
 } from './service';
+
+/**
+ * ワールド参加ログ DB エラー → UserFacingError 変換。
+ * 「ワールド参加ログの取得中にエラー」を一貫して表示するための SSOT。
+ */
+const mapWorldJoinLogDbError = toUserFacing<{ message: string }>({
+  code: ERROR_CODES.DATABASE_ERROR,
+  category: ERROR_CATEGORIES.DATABASE_ERROR,
+  userMessage: 'ワールド参加ログの取得中にエラーが発生しました。',
+});
 
 /**
  * 統合されたワールド参加ログを取得・マージ・ソートする共通関数

--- a/electron/module/logSync/logSyncController.ts
+++ b/electron/module/logSync/logSyncController.ts
@@ -1,13 +1,13 @@
 import { Effect } from 'effect';
-import { match } from 'ts-pattern';
 import z from 'zod';
 
 import { runEffect } from '../../lib/effectTRPC';
 import {
-  ERROR_CATEGORIES,
-  ERROR_CODES,
-  UserFacingError,
-} from '../../lib/errors';
+  mapByTag,
+  mapToUnknownError,
+  toUserFacing,
+} from '../../lib/errorMapping';
+import { ERROR_CATEGORIES, ERROR_CODES } from '../../lib/errors';
 import { procedure, router as trpcRouter } from '../../trpc';
 import { LOG_SYNC_MODE, type LogSyncMode, syncLogs } from './service';
 
@@ -17,40 +17,28 @@ const logSyncModeSchema = z.enum([
 ]);
 
 /**
- * ログ同期エラーを UserFacingError に変換するヘルパー
- * VRChatLogFileError, VRChatLogError, LogInfoError, LogInfoServiceError を統一的に処理
+ * ログ同期エラーを UserFacingError に変換するヘルパー。
+ *
+ * VRChatLogFileError, VRChatLogError, LogInfoError, LogInfoServiceError を
+ * `_tag` で分岐し、未知の tag は「ログ同期中にエラー」として扱う。
  */
-const mapSyncErrorToUserFacing = (e: { message: string; _tag?: string }) =>
-  match(e._tag)
-    .with('LogFileDirNotFound', () =>
-      UserFacingError.withStructuredInfo({
-        code: ERROR_CODES.VRCHAT_DIRECTORY_SETUP_REQUIRED,
-        category: ERROR_CATEGORIES.SETUP_REQUIRED,
-        message: e.message,
-        userMessage:
-          'VRChatのログディレクトリが見つかりません。VRChatがインストールされているか確認してください。',
-        cause: e instanceof Error ? e : new Error(e.message),
-      }),
-    )
-    .with('LogFilesNotFound', () =>
-      UserFacingError.withStructuredInfo({
-        code: ERROR_CODES.FILE_NOT_FOUND,
-        category: ERROR_CATEGORIES.FILE_NOT_FOUND,
-        message: e.message,
-        userMessage:
-          'VRChatのログファイルが見つかりません。VRChatを一度起動してから再度お試しください。',
-        cause: e instanceof Error ? e : new Error(e.message),
-      }),
-    )
-    .otherwise(() =>
-      UserFacingError.withStructuredInfo({
-        code: ERROR_CODES.UNKNOWN,
-        category: ERROR_CATEGORIES.UNKNOWN_ERROR,
-        message: e.message,
-        userMessage: 'ログ同期中にエラーが発生しました。',
-        cause: e instanceof Error ? e : new Error(e.message),
-      }),
-    );
+const mapSyncErrorToUserFacing = mapByTag<{ _tag?: string; message: string }>(
+  {
+    LogFileDirNotFound: toUserFacing({
+      code: ERROR_CODES.VRCHAT_DIRECTORY_SETUP_REQUIRED,
+      category: ERROR_CATEGORIES.SETUP_REQUIRED,
+      userMessage:
+        'VRChatのログディレクトリが見つかりません。VRChatがインストールされているか確認してください。',
+    }),
+    LogFilesNotFound: toUserFacing({
+      code: ERROR_CODES.FILE_NOT_FOUND,
+      category: ERROR_CATEGORIES.FILE_NOT_FOUND,
+      userMessage:
+        'VRChatのログファイルが見つかりません。VRChatを一度起動してから再度お試しください。',
+    }),
+  },
+  mapToUnknownError('ログ同期中にエラーが発生しました。'),
+);
 
 /**
  * ログ同期のためのtRPCルーター

--- a/electron/module/settings/settingsController.ts
+++ b/electron/module/settings/settingsController.ts
@@ -4,6 +4,7 @@ import { match, P } from 'ts-pattern';
 
 import { reloadMainWindow } from '../../electronUtil';
 import { runEffect } from '../../lib/effectTRPC';
+import { toUserFacing } from '../../lib/errorMapping';
 import {
   ERROR_CATEGORIES,
   ERROR_CODES,
@@ -21,45 +22,39 @@ import { procedure, router as trpcRouter } from './../../trpc';
 import type { UpdateError } from './errors';
 import * as settingService from './service';
 
+const mapUpdateErrorAsNetwork = toUserFacing<UpdateError>({
+  category: ERROR_CATEGORIES.NETWORK_ERROR,
+  userMessage: (e) => `アップデートに失敗しました: ${e.message}`,
+});
+
 /**
- * UpdateError → UserFacingError 変換ヘルパー（ネットワークエラーカテゴリ）
+ * UpdateError → UserFacingError 変換ヘルパー（ネットワークエラーカテゴリ）。
+ *
+ * E チャネルに `UpdateError | UserFacingError` が混在するケースのため、
+ * UserFacingError は素通し、UpdateError のみネットワークエラーとして変換する。
  */
 const mapUpdateError = (e: UpdateError | UserFacingError): UserFacingError => {
   if (e instanceof UserFacingError) {
     return e;
   }
-  return UserFacingError.withStructuredInfo({
-    code: ERROR_CODES.UNKNOWN,
-    category: ERROR_CATEGORIES.NETWORK_ERROR,
-    message: e.message,
-    userMessage: `アップデートに失敗しました: ${e.message}`,
-    cause: e,
-  });
+  return mapUpdateErrorAsNetwork(e);
 };
 
 /**
- * UpdateError → UserFacingError 変換ヘルパー（汎用カテゴリ）
+ * UpdateError → UserFacingError 変換ヘルパー（汎用カテゴリ）。
  */
-const mapUpdateErrorGeneric = (e: UpdateError): UserFacingError =>
-  UserFacingError.withStructuredInfo({
-    code: ERROR_CODES.UNKNOWN,
-    category: ERROR_CATEGORIES.UNKNOWN_ERROR,
-    message: e.message,
-    userMessage: `アップデートに失敗しました: ${e.message}`,
-    cause: e,
-  });
+const mapUpdateErrorGeneric = toUserFacing<UpdateError>({
+  userMessage: (e) => `アップデートに失敗しました: ${e.message}`,
+});
 
 /**
- * OpenPathFailed → UserFacingError 変換ヘルパー
+ * OpenPathFailed → UserFacingError 変換ヘルパー（ログフォルダ専用メッセージ）。
  */
-const mapOpenPathErrorForSettings = (e: OpenPathFailed): UserFacingError =>
-  UserFacingError.withStructuredInfo({
-    code: ERROR_CODES.FILE_NOT_FOUND,
-    category: ERROR_CATEGORIES.FILE_NOT_FOUND,
-    message: e.message,
-    userMessage: `ログフォルダを開けませんでした: ${e.message}`,
-    cause: e,
-  });
+const mapOpenPathErrorForSettings = toUserFacing<OpenPathFailed>({
+  code: ERROR_CODES.FILE_NOT_FOUND,
+  category: ERROR_CATEGORIES.FILE_NOT_FOUND,
+  userMessage: (e) => `ログフォルダを開けませんでした: ${e.message}`,
+});
 
 // 初期化処理の重複実行を防ぐためのフラグ
 let isInitializing = false;

--- a/electron/module/vrchatLog/exportService/exportService.ts
+++ b/electron/module/vrchatLog/exportService/exportService.ts
@@ -62,19 +62,13 @@ export type DBLogProvider = (
 /**
  * Electronのダウンロードパスを安全に取得。
  *
- * テスト環境では app が存在しないため null。
- * Electron 環境でも `getPath('downloads')` がプラットフォームによっては
- * 失敗する可能性があるため、その場合も null。
+ * `withElectronApp` が以下のいずれの失敗も fallback (null) に倒すため、
+ * 内部の try/catch は不要:
+ * - テスト/非 Electron 環境: `require('electron')` 失敗
+ * - Electron 環境: `app.getPath('downloads')` 失敗（プラットフォーム依存）
  */
 const getElectronDownloadsPath = (): string | null =>
-  withElectronApp<string | null>(null, (app) => {
-    // effect-lint-allow-try-catch: Electron環境検出パターン（app.getPath フォールバック）
-    try {
-      return app.getPath('downloads');
-    } catch {
-      return null;
-    }
-  });
+  withElectronApp<string | null>(null, (app) => app.getPath('downloads'));
 
 /**
  * デフォルトのlogStoreディレクトリパスを取得

--- a/electron/module/vrchatLog/exportService/exportService.ts
+++ b/electron/module/vrchatLog/exportService/exportService.ts
@@ -3,9 +3,9 @@ import * as path from 'node:path';
 
 import * as datefns from 'date-fns';
 import { Effect } from 'effect';
-import type Electron from 'electron';
 import { match } from 'ts-pattern';
 
+import { withElectronApp } from '../../../lib/electronModules';
 import {
   exportLogsToLogStore,
   formatLogStoreContent,
@@ -60,32 +60,21 @@ export type DBLogProvider = (
 ) => Promise<LogRecord[]>;
 
 /**
- * Electronのダウンロードパスを安全に取得
- * テスト環境などでappが利用できない場合はnullを返す
+ * Electronのダウンロードパスを安全に取得。
+ *
+ * テスト環境では app が存在しないため null。
+ * Electron 環境でも `getPath('downloads')` がプラットフォームによっては
+ * 失敗する可能性があるため、その場合も null。
  */
-const getElectronDownloadsPath = (): string | null => {
-  // Playwright テスト互換性のため遅延評価
-  // @see CLAUDE.md Electron Module Import パターン
-  const electronApp = (() => {
-    // effect-lint-allow-try-catch: Electron環境検出パターン（遅延require）
+const getElectronDownloadsPath = (): string | null =>
+  withElectronApp<string | null>(null, (app) => {
+    // effect-lint-allow-try-catch: Electron環境検出パターン（app.getPath フォールバック）
     try {
-      return (require('electron') as typeof Electron).app;
+      return app.getPath('downloads');
     } catch {
       return null;
     }
-  })();
-
-  if (!electronApp) {
-    return null;
-  }
-
-  // effect-lint-allow-try-catch: Electron環境検出パターン（app.getPath フォールバック）
-  try {
-    return electronApp.getPath('downloads');
-  } catch {
-    return null;
-  }
-};
+  });
 
 /**
  * デフォルトのlogStoreディレクトリパスを取得

--- a/electron/module/vrchatLog/vrchatLogController.integration.test.ts
+++ b/electron/module/vrchatLog/vrchatLogController.integration.test.ts
@@ -205,9 +205,11 @@ vi.mock('./backupService/backupService', async (importOriginal) => {
 });
 
 // ロールバックサービスのモック
-vi.mock('./backupService/rollbackService', async () => {
+vi.mock('./backupService/rollbackService', async (importOriginal) => {
+  const original = await importOriginal();
   const { Effect } = await import('effect');
   return {
+    ...(original as object),
     rollbackService: {
       rollbackToBackup: vi.fn((backup: ImportBackupMetadata) => {
         console.log('[Mock] rollbackToBackup called for backup:', backup.id);

--- a/electron/module/vrchatLog/vrchatLogController.ts
+++ b/electron/module/vrchatLog/vrchatLogController.ts
@@ -336,11 +336,15 @@ const reportFailureAsUserFacing = <E>(config: {
   return (e: E): UserFacingError => {
     const errorMessage = config.extractMessage(e);
     logger.error({ message: `${config.logLabel} failed: ${errorMessage}` });
+    // toast は常に「<操作名>に失敗しました: <詳細>」形式で出す（旧コード互換）。
+    // userMessage は `userMessageFromError: true` の場合のみ詳細メッセージ単体になる
+    // （旧 export ハンドラの挙動を維持）。
+    const prefixedMessage = `${config.userLabel}に失敗しました: ${errorMessage}`;
     const userMessage = config.userMessageFromError
       ? errorMessage
-      : `${config.userLabel}に失敗しました: ${errorMessage}`;
+      : prefixedMessage;
     if (config.emitToast !== false) {
-      eventEmitter.emit('toast', userMessage);
+      eventEmitter.emit('toast', prefixedMessage);
     }
     return UserFacingError.withStructuredInfo({
       code: config.code ?? ERROR_CODES.UNKNOWN,

--- a/electron/module/vrchatLog/vrchatLogController.ts
+++ b/electron/module/vrchatLog/vrchatLogController.ts
@@ -306,14 +306,18 @@ const getDBLogsFromDatabase = async (
 /**
  * バックアップ・エクスポート・インポート系の Effect.mapError 用ヘルパー。
  *
- * 4 ハンドラで重複していた以下のボイラープレートを単一の関数に集約:
+ * 6 ハンドラで重複していた以下のボイラープレートを単一の関数に集約:
  *   1. ドメイン固有 `getXxxErrorMessage(e)` でメッセージ抽出
  *   2. `logger.error` で英文ログ出力（Sentry 相関のため操作名 + 詳細を残す）
  *   3. `eventEmitter.emit('toast', ...)` でユーザー通知（オプション）
  *   4. `UserFacingError.withStructuredInfo` で型付きエラーに包む
  *
  * `userMessageFromError` を渡すと「エクスポート」のように生メッセージをそのまま
- * userMessage にする挙動も選択可能（4 ハンドラのうち 1 つだけ違うため）。
+ * userMessage にする挙動も選択可能（6 ハンドラのうち 1 つだけ違うため）。
+ *
+ * 注意: 各 mapXxxError は `vrchatLogRouter()` 関数内で構築する。
+ * トップレベルで構築するとモジュール読み込み時に `getXxxErrorMessage` 等を即時参照し、
+ * テスト側で対応する関数のモック忘れがあると `TypeError` を起こすため。
  */
 const reportFailureAsUserFacing = <E>(config: {
   /** 英文ログ用ラベル。例: "Export" → `"Export failed: ..."` */
@@ -343,52 +347,56 @@ const reportFailureAsUserFacing = <E>(config: {
       category: ERROR_CATEGORIES.UNKNOWN_ERROR,
       message: errorMessage,
       userMessage,
-      cause: e instanceof Error ? e : new Error(errorMessage),
+      // 元エラーが Error 派生（Data.TaggedError 等）ならそのまま渡し、
+      // そうでないものだけラップ。情報損失を最小化する。
+      cause: e instanceof Error ? e : new Error(errorMessage, { cause: e }),
     });
   };
 };
 
-const mapExportError = reportFailureAsUserFacing({
-  logLabel: 'Export',
-  userLabel: 'エクスポート',
-  code: ERROR_CODES.EXPORT_ERROR,
-  extractMessage: getExportErrorMessage,
-  userMessageFromError: true,
-});
+export const vrchatLogRouter = () => {
+  // mapXxxError は router 関数内に閉じ込め、`getXxxErrorMessage` 等の
+  // 遅延参照を保証する（テスト側のモック構築タイミングと整合させるため）。
+  const mapExportError = reportFailureAsUserFacing({
+    logLabel: 'Export',
+    userLabel: 'エクスポート',
+    code: ERROR_CODES.EXPORT_ERROR,
+    extractMessage: getExportErrorMessage,
+    userMessageFromError: true,
+  });
 
-const mapPreImportBackupError = reportFailureAsUserFacing({
-  logLabel: 'Pre-import backup',
-  userLabel: 'バックアップ作成',
-  extractMessage: getBackupErrorMessage,
-});
+  const mapPreImportBackupError = reportFailureAsUserFacing({
+    logLabel: 'Pre-import backup',
+    userLabel: 'バックアップ作成',
+    extractMessage: getBackupErrorMessage,
+  });
 
-const mapImportError = reportFailureAsUserFacing({
-  logLabel: 'LogStore import',
-  userLabel: 'インポート',
-  extractMessage: getImportErrorMessage,
-});
+  const mapImportError = reportFailureAsUserFacing({
+    logLabel: 'LogStore import',
+    userLabel: 'インポート',
+    extractMessage: getImportErrorMessage,
+  });
 
-const mapBackupHistoryError = reportFailureAsUserFacing({
-  logLabel: 'Failed to get backup history',
-  userLabel: 'バックアップ履歴の取得',
-  extractMessage: getBackupErrorMessage,
-  emitToast: false,
-});
+  const mapBackupHistoryError = reportFailureAsUserFacing({
+    logLabel: 'Failed to get backup history',
+    userLabel: 'バックアップ履歴の取得',
+    extractMessage: getBackupErrorMessage,
+    emitToast: false,
+  });
 
-const mapGetBackupError = reportFailureAsUserFacing({
-  logLabel: 'Failed to get backup',
-  userLabel: 'バックアップの取得',
-  extractMessage: getBackupErrorMessage,
-});
+  const mapGetBackupError = reportFailureAsUserFacing({
+    logLabel: 'Failed to get backup',
+    userLabel: 'バックアップの取得',
+    extractMessage: getBackupErrorMessage,
+  });
 
-const mapRollbackError = reportFailureAsUserFacing({
-  logLabel: 'Rollback',
-  userLabel: 'ロールバック',
-  extractMessage: getRollbackErrorMessage,
-});
+  const mapRollbackError = reportFailureAsUserFacing({
+    logLabel: 'Rollback',
+    userLabel: 'ロールバック',
+    extractMessage: getRollbackErrorMessage,
+  });
 
-export const vrchatLogRouter = () =>
-  trpcRouter({
+  return trpcRouter({
     appendLoglinesToFileFromLogFilePathList: procedure
       .input(
         z
@@ -529,3 +537,4 @@ export const vrchatLogRouter = () =>
         return { success: true, backup };
       }),
   });
+};

--- a/electron/module/vrchatLog/vrchatLogController.ts
+++ b/electron/module/vrchatLog/vrchatLogController.ts
@@ -5,6 +5,7 @@ import z from 'zod';
 import { runEffect } from '../../lib/effectTRPC';
 import {
   ERROR_CATEGORIES,
+  type ErrorCode,
   ERROR_CODES,
   UserFacingError,
 } from '../../lib/errors';
@@ -302,6 +303,90 @@ const getDBLogsFromDatabase = async (
   return logRecords;
 };
 
+/**
+ * バックアップ・エクスポート・インポート系の Effect.mapError 用ヘルパー。
+ *
+ * 4 ハンドラで重複していた以下のボイラープレートを単一の関数に集約:
+ *   1. ドメイン固有 `getXxxErrorMessage(e)` でメッセージ抽出
+ *   2. `logger.error` で英文ログ出力（Sentry 相関のため操作名 + 詳細を残す）
+ *   3. `eventEmitter.emit('toast', ...)` でユーザー通知（オプション）
+ *   4. `UserFacingError.withStructuredInfo` で型付きエラーに包む
+ *
+ * `userMessageFromError` を渡すと「エクスポート」のように生メッセージをそのまま
+ * userMessage にする挙動も選択可能（4 ハンドラのうち 1 つだけ違うため）。
+ */
+const reportFailureAsUserFacing = <E>(config: {
+  /** 英文ログ用ラベル。例: "Export" → `"Export failed: ..."` */
+  logLabel: string;
+  /** 日本語 toast/userMessage 用ラベル。例: "エクスポート" → `"エクスポートに失敗しました: ..."` */
+  userLabel: string;
+  /** ドメイン固有のエラーメッセージ抽出関数 */
+  extractMessage: (e: E) => string;
+  /** ERROR_CODES。デフォルト UNKNOWN */
+  code?: ErrorCode;
+  /** false なら toast を発行しない（getImportBackupHistory のみ） */
+  emitToast?: boolean;
+  /** true なら userMessage を生メッセージのみにする（exportLogStoreData のみ） */
+  userMessageFromError?: boolean;
+}) => {
+  return (e: E): UserFacingError => {
+    const errorMessage = config.extractMessage(e);
+    logger.error({ message: `${config.logLabel} failed: ${errorMessage}` });
+    const userMessage = config.userMessageFromError
+      ? errorMessage
+      : `${config.userLabel}に失敗しました: ${errorMessage}`;
+    if (config.emitToast !== false) {
+      eventEmitter.emit('toast', userMessage);
+    }
+    return UserFacingError.withStructuredInfo({
+      code: config.code ?? ERROR_CODES.UNKNOWN,
+      category: ERROR_CATEGORIES.UNKNOWN_ERROR,
+      message: errorMessage,
+      userMessage,
+      cause: e instanceof Error ? e : new Error(errorMessage),
+    });
+  };
+};
+
+const mapExportError = reportFailureAsUserFacing({
+  logLabel: 'Export',
+  userLabel: 'エクスポート',
+  code: ERROR_CODES.EXPORT_ERROR,
+  extractMessage: getExportErrorMessage,
+  userMessageFromError: true,
+});
+
+const mapPreImportBackupError = reportFailureAsUserFacing({
+  logLabel: 'Pre-import backup',
+  userLabel: 'バックアップ作成',
+  extractMessage: getBackupErrorMessage,
+});
+
+const mapImportError = reportFailureAsUserFacing({
+  logLabel: 'LogStore import',
+  userLabel: 'インポート',
+  extractMessage: getImportErrorMessage,
+});
+
+const mapBackupHistoryError = reportFailureAsUserFacing({
+  logLabel: 'Failed to get backup history',
+  userLabel: 'バックアップ履歴の取得',
+  extractMessage: getBackupErrorMessage,
+  emitToast: false,
+});
+
+const mapGetBackupError = reportFailureAsUserFacing({
+  logLabel: 'Failed to get backup',
+  userLabel: 'バックアップの取得',
+  extractMessage: getBackupErrorMessage,
+});
+
+const mapRollbackError = reportFailureAsUserFacing({
+  logLabel: 'Rollback',
+  userLabel: 'ロールバック',
+  extractMessage: getRollbackErrorMessage,
+});
+
 export const vrchatLogRouter = () =>
   trpcRouter({
     appendLoglinesToFileFromLogFilePathList: procedure
@@ -344,23 +429,7 @@ export const vrchatLogRouter = () =>
               outputBasePath: input.outputPath,
             },
             getDBLogsFromDatabase,
-          ).pipe(
-            Effect.mapError((e) => {
-              const errorMessage = getExportErrorMessage(e);
-              logger.error({ message: `Export failed: ${errorMessage}` });
-              eventEmitter.emit(
-                'toast',
-                `エクスポートに失敗しました: ${errorMessage}`,
-              );
-              return UserFacingError.withStructuredInfo({
-                code: ERROR_CODES.EXPORT_ERROR,
-                category: ERROR_CATEGORIES.UNKNOWN_ERROR,
-                message: errorMessage,
-                userMessage: errorMessage,
-                cause: e,
-              });
-            }),
-          ),
+          ).pipe(Effect.mapError(mapExportError)),
         );
 
         logger.info(
@@ -378,25 +447,9 @@ export const vrchatLogRouter = () =>
       logger.info('Creating pre-import backup');
 
       const backup = await runEffect(
-        backupService.createPreImportBackup(getDBLogsFromDatabase).pipe(
-          Effect.mapError((e) => {
-            const errorMessage = getBackupErrorMessage(e);
-            logger.error({
-              message: `Pre-import backup failed: ${errorMessage}`,
-            });
-            eventEmitter.emit(
-              'toast',
-              `バックアップ作成に失敗しました: ${errorMessage}`,
-            );
-            return UserFacingError.withStructuredInfo({
-              code: ERROR_CODES.UNKNOWN,
-              category: ERROR_CATEGORIES.UNKNOWN_ERROR,
-              message: errorMessage,
-              userMessage: `バックアップ作成に失敗しました: ${errorMessage}`,
-              cause: e,
-            });
-          }),
-        ),
+        backupService
+          .createPreImportBackup(getDBLogsFromDatabase)
+          .pipe(Effect.mapError(mapPreImportBackupError)),
       );
 
       logger.info(`Pre-import backup created successfully: ${backup.id}`);
@@ -422,25 +475,7 @@ export const vrchatLogRouter = () =>
         const result = await runEffect(
           importService
             .importLogStoreFiles(input.filePaths, getDBLogsFromDatabase)
-            .pipe(
-              Effect.mapError((e) => {
-                const errorMessage = getImportErrorMessage(e);
-                logger.error({
-                  message: `LogStore import failed: ${errorMessage}`,
-                });
-                eventEmitter.emit(
-                  'toast',
-                  `インポートに失敗しました: ${errorMessage}`,
-                );
-                return UserFacingError.withStructuredInfo({
-                  code: ERROR_CODES.UNKNOWN,
-                  category: ERROR_CATEGORIES.UNKNOWN_ERROR,
-                  message: errorMessage,
-                  userMessage: `インポートに失敗しました: ${errorMessage}`,
-                  cause: e,
-                });
-              }),
-            ),
+            .pipe(Effect.mapError(mapImportError)),
         );
 
         logger.info(
@@ -458,21 +493,9 @@ export const vrchatLogRouter = () =>
       logger.info('Getting import backup history');
 
       return runEffect(
-        backupService.getBackupHistory().pipe(
-          Effect.mapError((e) => {
-            const errorMessage = getBackupErrorMessage(e);
-            logger.error({
-              message: `Failed to get backup history: ${errorMessage}`,
-            });
-            return UserFacingError.withStructuredInfo({
-              code: ERROR_CODES.UNKNOWN,
-              category: ERROR_CATEGORIES.UNKNOWN_ERROR,
-              message: errorMessage,
-              userMessage: `バックアップ履歴の取得に失敗しました: ${errorMessage}`,
-              cause: e,
-            });
-          }),
-        ),
+        backupService
+          .getBackupHistory()
+          .pipe(Effect.mapError(mapBackupHistoryError)),
       );
     }),
     rollbackToBackup: procedure
@@ -486,45 +509,15 @@ export const vrchatLogRouter = () =>
         logger.info(`Starting rollback to backup: ${input.backupId}`);
 
         const backup = await runEffect(
-          backupService.getBackup(input.backupId).pipe(
-            Effect.mapError((e) => {
-              const errorMessage = getBackupErrorMessage(e);
-              logger.error({
-                message: `Failed to get backup: ${errorMessage}`,
-              });
-              eventEmitter.emit(
-                'toast',
-                `バックアップの取得に失敗しました: ${errorMessage}`,
-              );
-              return UserFacingError.withStructuredInfo({
-                code: ERROR_CODES.UNKNOWN,
-                category: ERROR_CATEGORIES.UNKNOWN_ERROR,
-                message: errorMessage,
-                userMessage: `バックアップの取得に失敗しました: ${errorMessage}`,
-                cause: e,
-              });
-            }),
-          ),
+          backupService
+            .getBackup(input.backupId)
+            .pipe(Effect.mapError(mapGetBackupError)),
         );
 
         await runEffect(
-          rollbackService.rollbackToBackup(backup).pipe(
-            Effect.mapError((e) => {
-              const errorMessage = getRollbackErrorMessage(e);
-              logger.error({ message: `Rollback failed: ${errorMessage}` });
-              eventEmitter.emit(
-                'toast',
-                `ロールバックに失敗しました: ${errorMessage}`,
-              );
-              return UserFacingError.withStructuredInfo({
-                code: ERROR_CODES.UNKNOWN,
-                category: ERROR_CATEGORIES.UNKNOWN_ERROR,
-                message: errorMessage,
-                userMessage: `ロールバックに失敗しました: ${errorMessage}`,
-                cause: e,
-              });
-            }),
-          ),
+          rollbackService
+            .rollbackToBackup(backup)
+            .pipe(Effect.mapError(mapRollbackError)),
         );
 
         logger.info(`Rollback completed successfully: ${input.backupId}`);

--- a/electron/module/vrchatLog/vrchatLogController.unit.test.ts
+++ b/electron/module/vrchatLog/vrchatLogController.unit.test.ts
@@ -29,6 +29,8 @@ vi.mock('./exportService/exportService', () => {
         exportEndTime: new Date(),
       }),
     ),
+    // mapExportError がトップレベルで参照するため、モック側でも export しておく必要がある
+    getExportErrorMessage: vi.fn((e: unknown) => String(e)),
   };
 });
 

--- a/electron/module/vrchatLog/vrchatLogController.unit.test.ts
+++ b/electron/module/vrchatLog/vrchatLogController.unit.test.ts
@@ -29,7 +29,9 @@ vi.mock('./exportService/exportService', () => {
         exportEndTime: new Date(),
       }),
     ),
-    // mapExportError がトップレベルで参照するため、モック側でも export しておく必要がある
+    // vi.mock はモジュールを完全に差し替えるため、controller 側の
+    // import { getExportErrorMessage } を解決させるためにも export 必須。
+    // 未指定だと undefined となり、エラー経路で TypeError を投げる。
     getExportErrorMessage: vi.fn(String),
   };
 });

--- a/electron/module/vrchatLog/vrchatLogController.unit.test.ts
+++ b/electron/module/vrchatLog/vrchatLogController.unit.test.ts
@@ -30,7 +30,7 @@ vi.mock('./exportService/exportService', () => {
       }),
     ),
     // mapExportError がトップレベルで参照するため、モック側でも export しておく必要がある
-    getExportErrorMessage: vi.fn((e: unknown) => String(e)),
+    getExportErrorMessage: vi.fn(String),
   };
 });
 

--- a/electron/module/vrchatPhoto/vrchatPhoto.controller.ts
+++ b/electron/module/vrchatPhoto/vrchatPhoto.controller.ts
@@ -4,17 +4,20 @@ import z from 'zod';
 import { runEffect } from '../../lib/effectTRPC';
 import { toUserFacing } from '../../lib/errorMapping';
 import { ERROR_CATEGORIES, ERROR_CODES } from '../../lib/errors';
-
-const mapPhotoNotFoundError = toUserFacing({
-  code: ERROR_CODES.FILE_NOT_FOUND,
-  category: ERROR_CATEGORIES.FILE_NOT_FOUND,
-  userMessage: '写真ファイルが見つかりません。',
-});
 import { logger } from './../../lib/logger';
 import { eventEmitter, procedure, router as trpcRouter } from './../../trpc';
 import * as utilsService from './../electronUtil/service';
 import * as vrchatPhotoService from './../vrchatPhoto/vrchatPhoto.service';
 import { VRChatPhotoDirPathSchema } from './valueObjects';
+
+/**
+ * 写真ファイルが見つからないエラー → UserFacingError 変換。
+ */
+const mapPhotoNotFoundError = toUserFacing({
+  code: ERROR_CODES.FILE_NOT_FOUND,
+  category: ERROR_CATEGORIES.FILE_NOT_FOUND,
+  userMessage: '写真ファイルが見つかりません。',
+});
 
 /**
  * index 済みの写真ファイルのpath一覧を取得する

--- a/electron/module/vrchatPhoto/vrchatPhoto.controller.ts
+++ b/electron/module/vrchatPhoto/vrchatPhoto.controller.ts
@@ -2,11 +2,14 @@ import { Cause, Effect, Exit, Option } from 'effect';
 import z from 'zod';
 
 import { runEffect } from '../../lib/effectTRPC';
-import {
-  ERROR_CATEGORIES,
-  ERROR_CODES,
-  UserFacingError,
-} from '../../lib/errors';
+import { toUserFacing } from '../../lib/errorMapping';
+import { ERROR_CATEGORIES, ERROR_CODES } from '../../lib/errors';
+
+const mapPhotoNotFoundError = toUserFacing({
+  code: ERROR_CODES.FILE_NOT_FOUND,
+  category: ERROR_CATEGORIES.FILE_NOT_FOUND,
+  userMessage: '写真ファイルが見つかりません。',
+});
 import { logger } from './../../lib/logger';
 import { eventEmitter, procedure, router as trpcRouter } from './../../trpc';
 import * as utilsService from './../electronUtil/service';
@@ -119,17 +122,9 @@ export const vrchatPhotoRouter = () =>
       .input(z.object({ photoPath: z.string(), width: z.number().optional() }))
       .mutation(async (ctx) => {
         return runEffect(
-          vrchatPhotoService.getVRChatPhotoItemData(ctx.input).pipe(
-            Effect.mapError((e) =>
-              UserFacingError.withStructuredInfo({
-                code: ERROR_CODES.FILE_NOT_FOUND,
-                category: ERROR_CATEGORIES.FILE_NOT_FOUND,
-                message: `Photo file operation error: ${String(e)}`,
-                userMessage: '写真ファイルが見つかりません。',
-                cause: new Error(String(e)),
-              }),
-            ),
-          ),
+          vrchatPhotoService
+            .getVRChatPhotoItemData(ctx.input)
+            .pipe(Effect.mapError(mapPhotoNotFoundError)),
         );
       }),
     getVRChatPhotoItemData: procedure.input(z.string()).query(async (ctx) => {

--- a/rules/ast-grep/no-duplicate-error-message-literal.yml
+++ b/rules/ast-grep/no-duplicate-error-message-literal.yml
@@ -1,0 +1,24 @@
+id: no-duplicate-error-message-literal
+language: TypeScript
+severity: warning
+message: |
+  この日本語ユーザーメッセージは electron/lib/errorMapping.ts で SSOT 化されています。
+  対応するヘルパーを使ってください:
+    - 'ファイル操作中にエラーが発生しました。' → mapToFileOperationError
+    - 'ファイルを開けませんでした。' → mapToOpenPathError
+note: |
+  メッセージ修正漏れを防ぐため、ユーザー向けメッセージはヘルパー経由で表示してください。
+  参照: electron/lib/errorMapping.ts
+rule:
+  any:
+    - pattern: "'ファイル操作中にエラーが発生しました。'"
+    - pattern: '"ファイル操作中にエラーが発生しました。"'
+    - pattern: "'ファイルを開けませんでした。'"
+    - pattern: '"ファイルを開けませんでした。"'
+files:
+  - electron/**/*.ts
+ignores:
+  - electron/lib/errorMapping.ts
+  - electron/lib/errorMapping.test.ts
+  - '**/*.test.ts'
+  - '**/*.spec.ts'

--- a/rules/ast-grep/require-electron-modules-helper.yml
+++ b/rules/ast-grep/require-electron-modules-helper.yml
@@ -3,20 +3,23 @@ language: TypeScript
 severity: error
 message: |
   require('electron') を直接使用しないでください。
-  代わりに electron/lib/electronModules.ts の遅延取得ヘルパー (getApp, getShell 等) を使用してください。
+  代わりに electron/lib/electronModules.ts の遅延取得ヘルパーを使用してください:
+    - 必須: getApp / getShell / getDialog / getClipboard / getNativeImage
+    - フォールバック付き: withElectronApp(fallback, fn)
 note: |
   参照: .claude/rules/electron-import.md
   ヘルパー: electron/lib/electronModules.ts
-  使用例: import { getApp } from '../../lib/electronModules';
+  使用例: import { getApp, withElectronApp } from '../../lib/electronModules';
 rule:
   pattern: require('electron')
 files:
   - electron/module/**/*.ts
+  - electron/lib/**/*.ts
 ignores:
   - '**/*.test.ts'
   - '**/*.spec.ts'
   - '**/__tests__/**'
-  # try-catch フォールバック付きの Electron 環境検出パターン（テスト環境対応）
-  - electron/module/imageGenerator/renderSvg.ts
-  - electron/module/vrchatLog/exportService/exportService.ts
+  # ヘルパー本体（ヘルパー自身が require('electron') を使う）
+  - electron/lib/electronModules.ts
+  # 詳細なエラーログを必要とするため withElectronApp 化が困難なケース
   - electron/module/vrchatPhoto/vrchatPhoto.service.ts

--- a/rules/ast-grep/use-error-mapping-helper.yml
+++ b/rules/ast-grep/use-error-mapping-helper.yml
@@ -1,0 +1,24 @@
+id: use-error-mapping-helper
+language: TypeScript
+severity: warning
+message: |
+  Effect.mapError 内で UserFacingError.withStructuredInfo を直接生成しないでください。
+  electron/lib/errorMapping.ts のヘルパー (toUserFacing / mapToFileOperationError /
+  mapToOpenPathError / mapToUnknownError / mapByTag) を使うか、
+  モジュールローカルのトップレベルにヘルパーを抽出してください。
+note: |
+  ボイラープレート（同じユーザーメッセージや cause 変換）が散在すると、
+  メッセージ修正漏れや Sentry 上の cause 欠落のリスクが上がります。
+  参照: .claude/rules/error-handling.md
+rule:
+  any:
+    - pattern: Effect.mapError(($$$ARGS) => UserFacingError.withStructuredInfo($$$BODY))
+    - pattern: Effect.mapError(($$$ARGS) => { $$$STMTS; return UserFacingError.withStructuredInfo($$$BODY); })
+    - pattern: Effect.mapError(($$$ARGS) => { $$$STMTS; return UserFacingError.withStructuredInfo($$$BODY) })
+files:
+  - electron/**/*.ts
+ignores:
+  - electron/lib/errorMapping.ts
+  - electron/lib/errorMapping.test.ts
+  - '**/*.test.ts'
+  - '**/*.spec.ts'


### PR DESCRIPTION
## Summary

Effect TS リファクタ。各 tRPC コントローラーで重複していたボイラープレートを SSOT 化し、ast-grep ルールで将来の再発も防ぐ。

- **errorMapping ヘルパー追加** (`electron/lib/errorMapping.ts`): `Effect.mapError(e => UserFacingError.withStructuredInfo({...}))` の重複を `toUserFacing` / `mapToFileOperationError` / `mapToOpenPathError` / `mapToUnknownError` / `mapByTag` に集約。8 ファイルで使用していた重複パターンを置換。
- **withElectronApp ヘルパー追加** (`electron/lib/electronModules.ts`): 「テスト環境ではフォールバック、Electron 環境では `app` を使う」パターンを高階関数化。`logger.ts` / `wrappedApp.ts` / `renderSvg.ts` / `exportService.ts` の try-catch + 遅延 require 重複を削減。
- **dbHelper.ts のクリーンアップ**: 未使用のコメントアウト 150 行と未使用エラー型 (`TRANSACTION_FAILED`, `RETRY_FAILED`) を削除。
- **ast-grep ルール 3 本追加/更新**:
  - `use-error-mapping-helper.yml`: `Effect.mapError` 内での `UserFacingError.withStructuredInfo` 直接生成を警告
  - `no-duplicate-error-message-literal.yml`: 「ファイル操作中にエラーが発生しました。」等の重複ユーザーメッセージリテラルを警告
  - `require-electron-modules-helper.yml`: `electron/lib/` 配下も対象化、`withElectronApp` 化済みファイルの ignore を解除

## Test plan

- [x] `pnpm lint` クリーン (既存の DateJumpSidebar の `match().otherwise()` 警告のみ残存)
- [x] `pnpm test` 全 811 pass / 4 skip (errorMapping のテスト 14 件含む)
- [x] `pnpm lint:type-check:tsc:electron` クリーン
- [x] ast-grep の新ルール 3 本が target 違反を 0 件で通過することを確認
- [x] セルフレビュー 2 回 (code-reviewer サブエージェント) 完了、Important 4 件 + Minor 9 件すべて修正済み

## Notes

- 残課題として「テスト try-catch を `runPromiseExit` に統一」は範囲が広い (35 箇所) ため別 PR 推奨
- `mapByTag` の `patterns` 型は `Partial<Record<NonNullable<E['_tag']>, ...>>` に厳格化済 (タグ名タイポをコンパイル時に検出可能)
- 既存挙動の互換性のため `toUserFacing` の `errorInfo.message` デフォルトは raw `e.message` を維持

https://claude.ai/code/session_01M9cvucgZso6vLXiTZZ96Ju