### PR TITLE
fix(deps): xmldom override を撤回して macOS ビルド失敗を解消

### DIFF
--- a/.changeset/fix-xmldom-override-narrow.md
+++ b/.changeset/fix-xmldom-override-narrow.md
@@ -1,0 +1,11 @@
+---
+'vrchat-albums': patch
+---
+
+fix(deps): macOS ビルドが plist パース失敗で落ちる問題を解消
+
+`electron-builder --mac` の `createMacApp` → `parsePlistFile` で `DOMParser.parseFromString: the provided mimeType "undefined" is not valid` が発生し macOS ビルドが必ず失敗していた問題を修正。
+
+原因は PR #815 で追加した `@xmldom/xmldom: ">=0.8.13"` override が upper bound を持たず `0.9.10` まで解決されていたこと。`@xmldom/xmldom@0.9.0` で DOMParser が仕様準拠化されて mimeType 引数が必須化された一方、`plist@3.1.0` は `parseFromString(xml)` のままで追従していないため、xmldom 0.9 系を引き込むと plist のパースが必ず失敗する。
+
+修正: `pnpm.overrides` の `@xmldom/xmldom` エントリを削除。これにより `plist@3.1.0` 自身の制約 `^0.8.8` が効き、`@xmldom/xmldom@0.8.13`（GHSA-9pgh-qqpf-7wqj 修正済み）に自然解決される。0.8 系の DOMParser は `parseFromString(xml)`（mimeType なし）呼び出しを許容するためプラットフォーム互換性が回復し、セキュリティ後退も発生しない。

--- a/package.json
+++ b/package.json
@@ -198,8 +198,7 @@
       "undici": ">=6.24.0",
       "picomatch": ">=4.0.4",
       "flatted": ">=3.4.2",
-      "smol-toml": ">=1.6.1",
-      "@xmldom/xmldom": ">=0.8.13"
+      "smol-toml": ">=1.6.1"
     },
     "onlyBuiltDependencies": [
       "@ast-grep/cli",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,6 @@ overrides:
   picomatch: '>=4.0.4'
   flatted: '>=3.4.2'
   smol-toml: '>=1.6.1'
-  '@xmldom/xmldom': '>=0.8.13'
 
 importers:
 
@@ -3657,9 +3656,9 @@ packages:
     peerDependencies:
       react: ^19
 
-  '@xmldom/xmldom@0.9.10':
-    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
-    engines: {node: '>=14.6'}
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+    engines: {node: '>=10.0.0'}
 
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -10161,7 +10160,7 @@ snapshots:
       lodash: 4.18.1
       react: 19.2.3
 
-  '@xmldom/xmldom@0.9.10': {}
+  '@xmldom/xmldom@0.8.13': {}
 
   abbrev@1.1.1: {}
 
@@ -12894,7 +12893,7 @@ snapshots:
 
   plist@3.1.0:
     dependencies:
-      '@xmldom/xmldom': 0.9.10
+      '@xmldom/xmldom': 0.8.13
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 


### PR DESCRIPTION
## Summary

`electron-builder --mac` の `createMacApp` → `parsePlistFile` で `DOMParser.parseFromString: the provided mimeType "undefined" is not valid` が発生し macOS ビルドが必ず失敗していた問題を、`pnpm.overrides` からの **1行削除のみ**で修正。

## 原因

PR #815 で追加した override `@xmldom/xmldom: ">=0.8.13"` が upper bound を持たず、pnpm が `@xmldom/xmldom@0.9.10` まで解決していた。

```
@xmldom/xmldom@0.9.0 で DOMParser が仕様準拠化、parseFromString の mimeType 引数が必須化
            ↓
plist@3.1.0 は parseFromString(xml) のまま（mimeType を渡していない）
            ↓
parsePlistFile が "the provided mimeType 'undefined' is not valid" で失敗
            ↓
macOS ビルドが必ず失敗
```

## 修正

```diff
# package.json
   "smol-toml": ">=1.6.1",
-  "@xmldom/xmldom": ">=0.8.13"
}
```

override を撤回すると、`plist@3.1.0` 自身の制約 `^0.8.8` が効いて `@xmldom/xmldom@0.8.13` に**自然解決**される。

- 0.8.13 は GHSA-9pgh-qqpf-7wqj が修正済みのバージョンなので**セキュリティ後退なし**
- 0.8 系の DOMParser は `parseFromString(xml)`（mimeType なし呼び出し）を許容するので互換性回復
- patch も override の追加も上流 PR も**何も不要**

## 経緯（補足）

当初は `pnpm patch` で `plist@3.1.0` を直接書き換える方針で実装していましたが、レビュー過程で「そもそも override の upper bound が無いのが原因で、削除するだけで自然解決する」と判明。force push で履歴を整理し、1コミット・1行削除に絞りました。

## Test plan

- [x] `pnpm install` で `@xmldom/xmldom` が `0.8.13` に自然解決されることを lockfile で確認
- [x] `pnpm audit` で xmldom 関連の脆弱性ゼロ（残存は `uuid`/`@tootallnate/once` の #815 で意図的 accepted されたもののみ）
- [x] 実機で `plist.parse(xml)` を mimeType なし呼び出しで実行 → `parse OK`
- [x] `pnpm lint` pass
- [x] `pnpm test` pass（812 passed / 4 skipped）
- [x] `pnpm build` pass
- [ ] CI の cross-platform `test (windows-latest)` / `test (ubuntu-22.04)` が緑
- [ ] CI の `Build on macos-latest` の検証は本リポジトリの構成上タグ push 時のみ走るため、merge 後にタグを切った段階で確認

## セルフレビュー

`.claude/rules/pr-self-review.md` に従い 2 サイクル実施済み（`codex` 不在のため `pr-review-toolkit:code-reviewer` で代替）。レビュー過程で patch 方針の不要性が露見し、より簡潔な現状の形に到達。

https://claude.ai/code/session_018oh3yqrpLow6Hg14Z5FquJ