### PR TITLE
chore(deps): pnpm overrides を 8→1 件に削減（脆弱性監査ベース）

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  tar: '>=7.5.11'
+
 importers:
 
   .:
@@ -6063,10 +6066,6 @@ packages:
     resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
     engines: {node: '>=8'}
 
-  minipass@5.0.0:
-    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
-    engines: {node: '>=8'}
-
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -7011,11 +7010,6 @@ packages:
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
-
-  tar@6.2.1:
-    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
-    engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.5.15:
     resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
@@ -11327,7 +11321,7 @@ snapshots:
       promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 8.0.1
-      tar: 6.2.1
+      tar: 7.5.15
       unique-filename: 1.1.1
     transitivePeerDependencies:
       - bluebird
@@ -11383,7 +11377,8 @@ snapshots:
 
   chownr@1.1.4: {}
 
-  chownr@2.0.0: {}
+  chownr@2.0.0:
+    optional: true
 
   chownr@3.0.0: {}
 
@@ -12175,6 +12170,7 @@ snapshots:
   fs-minipass@2.1.0:
     dependencies:
       minipass: 3.3.6
+    optional: true
 
   fs.realpath@1.0.0: {}
 
@@ -13250,8 +13246,7 @@ snapshots:
   minipass@3.3.6:
     dependencies:
       yallist: 4.0.0
-
-  minipass@5.0.0: {}
+    optional: true
 
   minipass@7.1.2: {}
 
@@ -13261,6 +13256,7 @@ snapshots:
     dependencies:
       minipass: 3.3.6
       yallist: 4.0.0
+    optional: true
 
   minizlib@3.1.0:
     dependencies:
@@ -13272,7 +13268,8 @@ snapshots:
     dependencies:
       minimist: 1.2.8
 
-  mkdirp@1.0.4: {}
+  mkdirp@1.0.4:
+    optional: true
 
   module-details-from-path@1.0.4: {}
 
@@ -13339,7 +13336,7 @@ snapshots:
       npmlog: 6.0.2
       rimraf: 3.0.2
       semver: 7.8.1
-      tar: 6.2.1
+      tar: 7.5.15
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -14238,7 +14235,7 @@ snapshots:
       bindings: 1.5.0
       node-addon-api: 7.1.1
       prebuild-install: 7.1.3
-      tar: 6.2.1
+      tar: 7.5.15
     optionalDependencies:
       node-gyp: 8.4.1
     transitivePeerDependencies:
@@ -14339,15 +14336,6 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
-
-  tar@6.2.1:
-    dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 5.0.0
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
 
   tar@7.5.15:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,16 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  tar: '>=7.5.11'
-  cacache>glob: 10.5.0
-  '@isaacs/brace-expansion': '>=5.0.1'
-  lodash: '>=4.18.0'
-  dottie: '>=2.0.7'
-  picomatch: '>=4.0.4'
-  flatted: '>=3.4.2'
-  smol-toml: '>=1.6.1'
-
 importers:
 
   .:
@@ -1301,10 +1291,6 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
-
-  '@isaacs/cliui@8.0.2':
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
 
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -2689,10 +2675,6 @@ packages:
 
   '@photostructure/tz-lookup@11.5.0':
     resolution: {integrity: sha512-0DVFriinZ7TeOnm9ytXeSL3NMFU87ZqMjgbPNkd8LgHFLcPg1BDyM1eewFYs+pPM+62S4fSP9Mtgijmn+6y95w==}
-
-  '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
 
   '@playwright/test@1.60.0':
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
@@ -4283,10 +4265,6 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
-    engines: {node: '>=12'}
-
   ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
     engines: {node: '>=4'}
@@ -4870,9 +4848,6 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-
   effect@3.21.2:
     resolution: {integrity: sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==}
 
@@ -4930,9 +4905,6 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   encoding@0.1.13:
     resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
@@ -5172,7 +5144,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: '>=4.0.4'
+      picomatch: ^3 || ^4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -5209,10 +5181,6 @@ packages:
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
-
-  foreground-child@3.3.1:
-    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
-    engines: {node: '>=14'}
 
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
@@ -5320,11 +5288,6 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
-
-  glob@10.5.0:
-    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
 
   glob@13.0.0:
     resolution: {integrity: sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==}
@@ -5611,9 +5574,6 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
-  jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
-
   jake@10.9.4:
     resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
     engines: {node: '>=10'}
@@ -5838,9 +5798,6 @@ packages:
   lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
-
-  lru-cache@10.4.3:
-    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@11.5.0:
     resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
@@ -6104,6 +6061,10 @@ packages:
 
   minipass@3.3.6:
     resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
+  minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
     engines: {node: '>=8'}
 
   minipass@7.1.2:
@@ -6407,10 +6368,6 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
-
   path-scurry@2.0.1:
     resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
     engines: {node: 20 || >=22}
@@ -6446,6 +6403,10 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -6972,10 +6933,6 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
-  string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
-
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
@@ -6985,10 +6942,6 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
-
-  strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
-    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -7058,6 +7011,11 @@ packages:
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
+
+  tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+    engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.5.15:
     resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
@@ -7563,10 +7521,6 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
-
-  wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -8596,16 +8550,6 @@ snapshots:
   '@inquirer/type@4.0.5(@types/node@22.15.35)':
     optionalDependencies:
       '@types/node': 22.15.35
-
-  '@isaacs/cliui@8.0.2':
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.2.0
-      strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: wrap-ansi@7.0.0
-    optional: true
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
@@ -9660,9 +9604,6 @@ snapshots:
     optional: true
 
   '@photostructure/tz-lookup@11.5.0': {}
-
-  '@pkgjs/parseargs@0.11.0':
-    optional: true
 
   '@playwright/test@1.60.0':
     dependencies:
@@ -11148,9 +11089,6 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
-  ansi-regex@6.2.2:
-    optional: true
-
   ansi-styles@3.2.1:
     dependencies:
       color-convert: 1.9.3
@@ -11377,7 +11315,7 @@ snapshots:
       '@npmcli/move-file': 1.1.2
       chownr: 2.0.0
       fs-minipass: 2.1.0
-      glob: 10.5.0
+      glob: 7.2.3
       infer-owner: 1.0.4
       lru-cache: 6.0.0
       minipass: 3.3.6
@@ -11389,7 +11327,7 @@ snapshots:
       promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 8.0.1
-      tar: 7.5.15
+      tar: 6.2.1
       unique-filename: 1.1.1
     transitivePeerDependencies:
       - bluebird
@@ -11445,8 +11383,7 @@ snapshots:
 
   chownr@1.1.4: {}
 
-  chownr@2.0.0:
-    optional: true
+  chownr@2.0.0: {}
 
   chownr@3.0.0: {}
 
@@ -11750,9 +11687,6 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  eastasianwidth@0.2.0:
-    optional: true
-
   effect@3.21.2:
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -11857,9 +11791,6 @@ snapshots:
       node-addon-api: 7.1.1
 
   emoji-regex@8.0.0: {}
-
-  emoji-regex@9.2.2:
-    optional: true
 
   encoding@0.1.13:
     dependencies:
@@ -12192,12 +12123,6 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  foreground-child@3.3.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
-    optional: true
-
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -12250,7 +12175,6 @@ snapshots:
   fs-minipass@2.1.0:
     dependencies:
       minipass: 3.3.6
-    optional: true
 
   fs.realpath@1.0.0: {}
 
@@ -12321,16 +12245,6 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
-
-  glob@10.5.0:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.9
-      minipass: 7.1.3
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
-    optional: true
 
   glob@13.0.0:
     dependencies:
@@ -12638,13 +12552,6 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
-  jackspeak@3.4.3:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
-    optional: true
-
   jake@10.9.4:
     dependencies:
       async: 3.2.6
@@ -12857,9 +12764,6 @@ snapshots:
   longest-streak@3.1.0: {}
 
   lowercase-keys@2.0.0: {}
-
-  lru-cache@10.4.3:
-    optional: true
 
   lru-cache@11.5.0: {}
 
@@ -13278,7 +13182,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 4.0.4
+      picomatch: 2.3.2
 
   mime-db@1.52.0: {}
 
@@ -13346,7 +13250,8 @@ snapshots:
   minipass@3.3.6:
     dependencies:
       yallist: 4.0.0
-    optional: true
+
+  minipass@5.0.0: {}
 
   minipass@7.1.2: {}
 
@@ -13356,7 +13261,6 @@ snapshots:
     dependencies:
       minipass: 3.3.6
       yallist: 4.0.0
-    optional: true
 
   minizlib@3.1.0:
     dependencies:
@@ -13368,8 +13272,7 @@ snapshots:
     dependencies:
       minimist: 1.2.8
 
-  mkdirp@1.0.4:
-    optional: true
+  mkdirp@1.0.4: {}
 
   module-details-from-path@1.0.4: {}
 
@@ -13436,7 +13339,7 @@ snapshots:
       npmlog: 6.0.2
       rimraf: 3.0.2
       semver: 7.8.1
-      tar: 7.5.15
+      tar: 6.2.1
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -13740,12 +13643,6 @@ snapshots:
 
   path-parse@1.0.7: {}
 
-  path-scurry@1.11.1:
-    dependencies:
-      lru-cache: 10.4.3
-      minipass: 7.1.3
-    optional: true
-
   path-scurry@2.0.1:
     dependencies:
       lru-cache: 11.5.0
@@ -13777,6 +13674,8 @@ snapshots:
       postgres-interval: 1.2.0
 
   picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
 
@@ -14339,7 +14238,7 @@ snapshots:
       bindings: 1.5.0
       node-addon-api: 7.1.1
       prebuild-install: 7.1.3
-      tar: 7.5.15
+      tar: 6.2.1
     optionalDependencies:
       node-gyp: 8.4.1
     transitivePeerDependencies:
@@ -14365,13 +14264,6 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
-  string-width@5.1.2:
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.2.0
-    optional: true
-
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -14384,11 +14276,6 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
-
-  strip-ansi@7.2.0:
-    dependencies:
-      ansi-regex: 6.2.2
-    optional: true
 
   strip-bom@3.0.0: {}
 
@@ -14452,6 +14339,15 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  tar@6.2.1:
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
 
   tar@7.5.15:
     dependencies:
@@ -14876,13 +14772,6 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-
-  wrap-ansi@8.1.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 5.1.2
-      strip-ansi: 7.2.0
-    optional: true
 
   wrappy@1.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,17 +51,25 @@ allowBuilds:
   simple-git-hooks: true # pre-commit フックのセットアップ
   sqlite3: true # ネイティブモジュールのビルド
 
-
 # === 依存バージョンの上書き（脆弱性対応 / 互換性確保） ===
-# overrides は原則使わない方針。
-# 過去に脆弱性対応として tar / cacache>glob / picomatch / lodash / dottie /
-# flatted / smol-toml / @isaacs/brace-expansion を強制していたが、以下の理由で撤去した:
+# overrides は最小限に保つ方針。脆弱性対応で本当に必要なものだけを残す。
+#
+# 撤去したもの（8 → 1 件に削減）:
 #   - lodash / dottie / flatted / smol-toml / @isaacs/brace-expansion:
 #     resolutionMode: highest により override 無しでも同一の安全な版に解決されるため冗長だった。
-#   - tar(>=7.5.11) / picomatch(>=4.0.4) / cacache>glob(10.5.0):
-#     sqlite3 / micromatch / cacache などビルド・install 時専用の推移的依存に対し
-#     メジャーバージョン跨ぎ（tar 6→7 / picomatch 2→4 / glob 7→10）を強制しており、
-#     依存元が宣言するレンジと非互換で脆く、管理コストが高かった。各依存元の宣言レンジに
-#     戻し、最新パッチは resolutionMode: highest に委ねる。
+#   - picomatch(>=4.0.4) / cacache>glob(10.5.0):
+#     micromatch / cacache などビルド・install 時専用の推移的依存にメジャー跨ぎ
+#     （picomatch 2→4 / glob 7→10）を強制していたが、撤去後も `pnpm audit` で
+#     脆弱性は検出されなかったため、依存元の宣言レンジ（picomatch@2 / glob@7）へ戻した。
+#
+# 残したもの:
+#   - tar: sqlite3@5.1.7（node-sqlite3 最新）が tar@^6 をピンしており、撤去すると
+#     tar@6.2.1 に解決されて high 脆弱性 6 件（GHSA-r6q2-hw4h-h46w 等、いずれも
+#     patched >=7.5.4〜>=7.5.11）が復活する。引き込み元の sqlite3 / @sequelize/sqlite3
+#     はいずれも最新版で tar@7 系へ上げる手段がないため、override で >=7.5.11 を強制する。
+#     install/build 時のみ使う依存で、tar 6→7 の強制は実環境（native rebuild）で検証済み。
+#
 # 新たな脆弱性は Dependabot / supply-chain-scan で検知し、まず直接依存のアップグレードで
 # 解消する。それでも塞げない場合のみ、理由をコメントで明記した上で override を追加する。
+overrides:
+  tar: '>=7.5.11'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -64,9 +64,11 @@ allowBuilds:
 #
 # 残したもの:
 #   - tar: sqlite3@5.1.7（node-sqlite3 最新）が tar@^6 をピンしており、撤去すると
-#     tar@6.2.1 に解決されて high 脆弱性 6 件（GHSA-r6q2-hw4h-h46w 等、いずれも
-#     patched >=7.5.4〜>=7.5.11）が復活する。引き込み元の sqlite3 / @sequelize/sqlite3
-#     はいずれも最新版で tar@7 系へ上げる手段がないため、override で >=7.5.11 を強制する。
+#     tar@6.2.1 に解決されて node-tar の high 脆弱性（GHSA-r6q2-hw4h-h46w 等、2026 年
+#     1〜3 月公開の複数件）が復活する。引き込み元の sqlite3（5.1.7 が最新）と
+#     @sequelize/sqlite3（7.0.0-alpha.x が最新ライン）はいずれも tar@7 系へ上げる手段が
+#     ないため、override で tar を最新パッチ版へ引き上げて塞ぐ。具体的な脆弱バージョンと
+#     必要な下限は `pnpm audit` を一次情報とすること（floor は patched 版の最大に追従させる）。
 #     install/build 時のみ使う依存で、tar 6→7 の強制は実環境（native rebuild）で検証済み。
 #
 # 新たな脆弱性は Dependabot / supply-chain-scan で検知し、まず直接依存のアップグレードで

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,27 +51,18 @@ allowBuilds:
   simple-git-hooks: true # pre-commit フックのセットアップ
   sqlite3: true # ネイティブモジュールのビルド
 
-# === 依存バージョンの上書き（脆弱性対応 / 互換性確保） ===
-# overrides は最小限に保つ方針。脆弱性対応で本当に必要なものだけを残す。
+# === 依存バージョンの上書き（overrides） ===
+# 方針: overrides は最小限に保つ。脆弱性は原則として直接依存のアップグレードで解消し、
+# それが不可能な推移的依存に限って override で塞ぐ。override 無しでも同じ版に解決される
+# 冗長な指定は置かない（解決方針は resolutionMode: highest に委ねる）。
 #
-# 撤去したもの（8 → 1 件に削減）:
-#   - lodash / dottie / flatted / smol-toml / @isaacs/brace-expansion:
-#     resolutionMode: highest により override 無しでも同一の安全な版に解決されるため冗長だった。
-#   - picomatch(>=4.0.4) / cacache>glob(10.5.0):
-#     micromatch / cacache などビルド・install 時専用の推移的依存にメジャー跨ぎ
-#     （picomatch 2→4 / glob 7→10）を強制していたが、撤去後も `pnpm audit` で
-#     脆弱性は検出されなかったため、依存元の宣言レンジ（picomatch@2 / glob@7）へ戻した。
+# tar: node-sqlite3（@sequelize/sqlite3 が依存）が古いメジャーの tar をピンしており、
+#   その系統には既知の脆弱性がある。引き込み元の sqlite3 / @sequelize/sqlite3 を、
+#   patched な tar を引く版へ上げる手段が無いため、override で patched 版へ引き上げて塞ぐ。
+#   tar は install/build 時のみ使われ、メジャー跨ぎの強制が動作することは native rebuild で
+#   検証している。必要な下限は `pnpm audit` を一次情報として patched 版に追従させること。
 #
-# 残したもの:
-#   - tar: sqlite3@5.1.7（node-sqlite3 最新）が tar@^6 をピンしており、撤去すると
-#     tar@6.2.1 に解決されて node-tar の high 脆弱性（GHSA-r6q2-hw4h-h46w 等、2026 年
-#     1〜3 月公開の複数件）が復活する。引き込み元の sqlite3（5.1.7 が最新）と
-#     @sequelize/sqlite3（7.0.0-alpha.x が最新ライン）はいずれも tar@7 系へ上げる手段が
-#     ないため、override で tar を最新パッチ版へ引き上げて塞ぐ。具体的な脆弱バージョンと
-#     必要な下限は `pnpm audit` を一次情報とすること（floor は patched 版の最大に追従させる）。
-#     install/build 時のみ使う依存で、tar 6→7 の強制は実環境（native rebuild）で検証済み。
-#
-# 新たな脆弱性は Dependabot / supply-chain-scan で検知し、まず直接依存のアップグレードで
-# 解消する。それでも塞げない場合のみ、理由をコメントで明記した上で override を追加する。
+# override を追加・変更するときは、まず直接依存のアップグレードで解消できないかを検討し、
+# できない場合のみ理由を添えてここに記載する。
 overrides:
   tar: '>=7.5.11'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,13 +51,17 @@ allowBuilds:
   simple-git-hooks: true # pre-commit フックのセットアップ
   sqlite3: true # ネイティブモジュールのビルド
 
+
 # === 依存バージョンの上書き（脆弱性対応 / 互換性確保） ===
-overrides:
-  tar: '>=7.5.11'
-  cacache>glob: '10.5.0'
-  '@isaacs/brace-expansion': '>=5.0.1'
-  lodash: '>=4.18.0'
-  dottie: '>=2.0.7'
-  picomatch: '>=4.0.4'
-  flatted: '>=3.4.2'
-  smol-toml: '>=1.6.1'
+# overrides は原則使わない方針。
+# 過去に脆弱性対応として tar / cacache>glob / picomatch / lodash / dottie /
+# flatted / smol-toml / @isaacs/brace-expansion を強制していたが、以下の理由で撤去した:
+#   - lodash / dottie / flatted / smol-toml / @isaacs/brace-expansion:
+#     resolutionMode: highest により override 無しでも同一の安全な版に解決されるため冗長だった。
+#   - tar(>=7.5.11) / picomatch(>=4.0.4) / cacache>glob(10.5.0):
+#     sqlite3 / micromatch / cacache などビルド・install 時専用の推移的依存に対し
+#     メジャーバージョン跨ぎ（tar 6→7 / picomatch 2→4 / glob 7→10）を強制しており、
+#     依存元が宣言するレンジと非互換で脆く、管理コストが高かった。各依存元の宣言レンジに
+#     戻し、最新パッチは resolutionMode: highest に委ねる。
+# 新たな脆弱性は Dependabot / supply-chain-scan で検知し、まず直接依存のアップグレードで
+# 解消する。それでも塞げない場合のみ、理由をコメントで明記した上で override を追加する。


### PR DESCRIPTION
## 概要

`pnpm-workspace.yaml` の overrides 管理が辛いため、`pnpm audit` ベースで安全に削減できるものを精査し、**8 件 → 1 件（tar のみ）** に整理しました。

## 背景

overrides は脆弱性対応・互換性確保のための推移的依存バージョン強制ですが、ビルドツール系依存にメジャー跨ぎを強制するものが含まれ、管理コストが高い状態でした。

## やったこと

override の有無で `pnpm install --lockfile-only` を再解決して影響を実証比較し、`pnpm audit` で脆弱性復活の有無を確認しました。

### 撤去（7 件）

| override | 理由 |
|---|---|
| `lodash` `dottie` `flatted` `smol-toml` `@isaacs/brace-expansion` | `resolutionMode: highest` により override 無しでも**同一の安全な版に解決**されるため冗長（lockfile の実解決は不変） |
| `picomatch` (`>=4.0.4`) `cacache>glob` (`10.5.0`) | `micromatch` / `cacache` などビルド・install 時専用の推移的依存へメジャー跨ぎ（picomatch 2→4 / glob 7→10）を強制していたが、**撤去後も `pnpm audit` で脆弱性ゼロ**のため依存元の宣言レンジへ戻した |

### 維持（1 件）

| override | 理由 |
|---|---|
| `tar` (`>=7.5.11`) | 撤去すると `@sequelize/sqlite3 > sqlite3 > tar` 経由で `tar@6.2.1` に解決され、**node-tar の high 脆弱性 6 件**（GHSA-r6q2-hw4h-h46w 等、2026/1〜3 公開）が復活する。引き込み元の `sqlite3@5.1.7`・`@sequelize/sqlite3@7.0.0-alpha.48` はいずれも最新で **tar@7 系へ上げる手段がない**ため override を維持。install/build 時のみ使う依存で、tar 6→7 強制は native rebuild で動作検証済み |

判断根拠は `pnpm-workspace.yaml` のコメントに明記しています。

## 検証

- `pnpm lint` ✅ / `pnpm test` ✅（**812 passed** / 92 files）/ `pnpm build` ✅ / `pnpm knip` ✅
- `pnpm install --frozen-lockfile` 整合 ✅ / native rebuild（sqlite3）✅ / pre-commit フック ✅
- `pnpm audit`: **override 撤去起因の脆弱性ゼロ**

## 補足（このPRの対象外）

監査で検出された `exiftool-vendored`（high, patched `>=35.18.1`）と `@tootallnate/once`（low）は **override 無関係の main 既存課題**です。`exiftool-vendored` は Rust napi-rs 移行後、互換性検証テストとコメントでのみ参照されているため、別途バージョン更新 or devDependencies 化で対応可能です。

https://claude.ai/code/session_01KEKwj4Qvn4iBdZSbR4inuD

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEKwj4Qvn4iBdZSbR4inuD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration to optimize compatibility and security constraints while removing redundant overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->